### PR TITLE
Plan B fast-follows: cap 429 backoff + Riot ID whitespace normalization

### DIFF
--- a/riot-account-core/src/main/java/com/muddl/riot/account/identity/PlayerIdentityResolver.java
+++ b/riot-account-core/src/main/java/com/muddl/riot/account/identity/PlayerIdentityResolver.java
@@ -52,11 +52,16 @@ public class PlayerIdentityResolver {
             return trimmed; // already a PUUID — nothing to resolve, no Riot call, no cache entry
         }
         String[] parts = trimmed.split("#", -1);
-        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+        if (parts.length != 2) {
             throw new IllegalArgumentException(unparseableMessage(player));
         }
-        String gameName = parts[0];
-        String tagLine = parts[1];
+        // Trim each half so "Faker # KR1" normalizes to the same PUUID and cache key as "Faker#KR1"
+        // (internal spaces in a game name are preserved — only surrounding whitespace is removed).
+        String gameName = parts[0].trim();
+        String tagLine = parts[1].trim();
+        if (gameName.isBlank() || tagLine.isBlank()) {
+            throw new IllegalArgumentException(unparseableMessage(player));
+        }
         // get(key, loader) is atomic per key; a loader that throws (unknown Riot ID) propagates and
         // caches nothing, which is exactly the "do not cache failed lookups" behaviour we want.
         return puuidByRiotId.get(gameName + "#" + tagLine, key -> lookupPuuid(gameName, tagLine));

--- a/riot-account-core/src/test/java/com/muddl/riot/account/identity/PlayerIdentityResolverTest.java
+++ b/riot-account-core/src/test/java/com/muddl/riot/account/identity/PlayerIdentityResolverTest.java
@@ -14,6 +14,8 @@ class PlayerIdentityResolverTest {
     /** A port that counts Riot-ID lookups, so a cache hit is provable as "one call across two lookups". */
     private static final class CountingPort implements RiotAccountPort {
         private int riotIdLookups = 0;
+        private String lastGameName;
+        private String lastTagLine;
         private final RiotAccount account;
 
         CountingPort(RiotAccount account) {
@@ -23,6 +25,8 @@ class PlayerIdentityResolverTest {
         @Override
         public RiotAccount getAccountByRiotId(String gameName, String tagLine) {
             riotIdLookups++;
+            lastGameName = gameName;
+            lastTagLine = tagLine;
             return account;
         }
 
@@ -89,6 +93,25 @@ class PlayerIdentityResolverTest {
         resolver.resolvePuuid("Faker#KR1");
 
         assertThat(port.riotIdLookups).isEqualTo(2); // staleness bounded — mutable Riot IDs re-checked
+    }
+
+    @Test
+    void trims_whitespace_around_each_riot_id_component() {
+        RiotAccount account = RiotAccount.builder()
+                .puuid("resolved-puuid")
+                .gameName("Faker")
+                .tagLine("KR1")
+                .build();
+        CountingPort port = new CountingPort(account);
+        PlayerIdentityResolver resolver = resolver(port, new MutableTicker());
+
+        assertThat(resolver.resolvePuuid("Faker # KR1")).isEqualTo("resolved-puuid");
+        assertThat(port.lastGameName).isEqualTo("Faker"); // trimmed, not "Faker "
+        assertThat(port.lastTagLine).isEqualTo("KR1"); // trimmed, not " KR1"
+
+        // Spaced variants normalize to the same cache key, so no second Riot call.
+        resolver.resolvePuuid("  Faker#KR1  ");
+        assertThat(port.riotIdLookups).isEqualTo(1);
     }
 
     @Test

--- a/riot-api-core/CHANGELOG.md
+++ b/riot-api-core/CHANGELOG.md
@@ -14,8 +14,9 @@ whole repo — see [ADR-0010](../docs/knowledge/decisions/ADR-0010-versioning-an
 
 ### Added
 - Automatic retry on HTTP 429, honouring the `Retry-After` header (falling back to a configurable
-  `riot.retry-backoff`, default 1s) up to `riot.max-retries` attempts (default 3). This is reactive
-  retry, not a proactive rate limiter — see [ADR-0007](../docs/knowledge/decisions/ADR-0007-core-hardening-boundary.md).
+  `riot.retry-backoff`, default 1s) up to `riot.max-retries` attempts (default 3), with each wait
+  capped at `riot.max-retry-backoff` (default 120s) so a hostile or erroneous header cannot stall a
+  thread. This is reactive retry, not a proactive rate limiter — see [ADR-0007](../docs/knowledge/decisions/ADR-0007-core-hardening-boundary.md).
 
 ### Changed
 - **Breaking:** coordinates are now `com.muddl`, package root `com.muddl.riot.core`.

--- a/riot-api-core/src/main/java/com/muddl/riot/core/config/RiotApiProperties.java
+++ b/riot-api-core/src/main/java/com/muddl/riot/core/config/RiotApiProperties.java
@@ -32,4 +32,11 @@ public class RiotApiProperties {
 
     /** Backoff used between 429 retries when the response carries no usable {@code Retry-After}. */
     private Duration retryBackoff = Duration.ofSeconds(1);
+
+    /**
+     * Upper bound on a single 429 backoff, even when {@code Retry-After} asks for longer. Riot's
+     * application-rate-limit 429 can legitimately specify up to ~120s; this caps pathological or
+     * hostile header values so one tool call cannot block a thread indefinitely.
+     */
+    private Duration maxRetryBackoff = Duration.ofSeconds(120);
 }

--- a/riot-api-core/src/main/java/com/muddl/riot/core/http/RetryOn429Interceptor.java
+++ b/riot-api-core/src/main/java/com/muddl/riot/core/http/RetryOn429Interceptor.java
@@ -26,11 +26,13 @@ class RetryOn429Interceptor implements ClientHttpRequestInterceptor {
 
     private final int maxRetries;
     private final Duration defaultBackoff;
+    private final Duration maxBackoff;
     private final BackoffSleeper sleeper;
 
-    RetryOn429Interceptor(int maxRetries, Duration defaultBackoff, BackoffSleeper sleeper) {
+    RetryOn429Interceptor(int maxRetries, Duration defaultBackoff, Duration maxBackoff, BackoffSleeper sleeper) {
         this.maxRetries = maxRetries;
         this.defaultBackoff = defaultBackoff;
+        this.maxBackoff = maxBackoff;
         this.sleeper = sleeper;
     }
 
@@ -40,13 +42,18 @@ class RetryOn429Interceptor implements ClientHttpRequestInterceptor {
         ClientHttpResponse response = execution.execute(request, body);
         int attempt = 0;
         while (response.getStatusCode().value() == TOO_MANY_REQUESTS && attempt < maxRetries) {
-            Duration wait = retryAfter(response).orElse(defaultBackoff);
+            Duration wait = clampToMax(retryAfter(response).orElse(defaultBackoff));
             response.close();
             sleeper.sleep(wait);
             attempt++;
             response = execution.execute(request, body);
         }
         return response;
+    }
+
+    /** Caps a wait at {@code maxBackoff} so a hostile or erroneous {@code Retry-After} cannot stall a thread. */
+    private Duration clampToMax(Duration wait) {
+        return wait.compareTo(maxBackoff) > 0 ? maxBackoff : wait;
     }
 
     private Optional<Duration> retryAfter(ClientHttpResponse response) {

--- a/riot-api-core/src/main/java/com/muddl/riot/core/http/RiotApiClient.java
+++ b/riot-api-core/src/main/java/com/muddl/riot/core/http/RiotApiClient.java
@@ -48,8 +48,11 @@ public class RiotApiClient {
         return RestClient.builder()
                 .baseUrl(resolveBaseUrl(host))
                 .defaultHeader(RIOT_TOKEN_HEADER, properties.getApiKey())
-                .requestInterceptor(
-                        new RetryOn429Interceptor(properties.getMaxRetries(), properties.getRetryBackoff(), sleeper))
+                .requestInterceptor(new RetryOn429Interceptor(
+                        properties.getMaxRetries(),
+                        properties.getRetryBackoff(),
+                        properties.getMaxRetryBackoff(),
+                        sleeper))
                 .defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
                     String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
                     throw RiotApiException.forStatus(response.getStatusCode().value(), body);

--- a/riot-api-core/src/test/java/com/muddl/riot/core/http/RiotApiClientTest.java
+++ b/riot-api-core/src/test/java/com/muddl/riot/core/http/RiotApiClientTest.java
@@ -189,4 +189,52 @@ class RiotApiClientTest {
         assertThat(sleeper.waits).isEmpty();
         verify(exactly(1), getRequestedFor(urlEqualTo("/forbidden")));
     }
+
+    @Test
+    void clamps_an_excessive_retry_after_to_the_max_backoff() {
+        stubFor(get(urlEqualTo("/retry"))
+                .inScenario("clamp")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "99999"))
+                .willSetStateTo("recovered"));
+        stubFor(get(urlEqualTo("/retry"))
+                .inScenario("clamp")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse().withStatus(200).withBody("ok")));
+
+        RecordingSleeper sleeper = new RecordingSleeper();
+        clientWith(sleeper, 3, Duration.ofSeconds(1))
+                .platform(RiotApiPlatformUri.NA1)
+                .get()
+                .uri("/retry")
+                .retrieve()
+                .body(String.class);
+
+        // 99999s is clamped to the default max (120s) so one call cannot block a thread indefinitely.
+        assertThat(sleeper.waits).containsExactly(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void falls_back_to_the_default_backoff_on_an_unparseable_retry_after() {
+        stubFor(get(urlEqualTo("/retry"))
+                .inScenario("bad-header")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "banana"))
+                .willSetStateTo("recovered"));
+        stubFor(get(urlEqualTo("/retry"))
+                .inScenario("bad-header")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse().withStatus(200).withBody("ok")));
+
+        RecordingSleeper sleeper = new RecordingSleeper();
+        clientWith(sleeper, 3, Duration.ofMillis(250))
+                .platform(RiotApiPlatformUri.NA1)
+                .get()
+                .uri("/retry")
+                .retrieve()
+                .body(String.class);
+
+        // A non-numeric Retry-After is unusable, so the interceptor uses the configured default.
+        assertThat(sleeper.waits).containsExactly(Duration.ofMillis(250));
+    }
 }


### PR DESCRIPTION
## Summary

The non-gating fast-follows noted at merge time in the Plan B whole-branch review.

- **`riot-api-core`** — cap each 429 retry wait at `riot.max-retry-backoff` (default 120s) so a large or hostile `Retry-After` (Riot application-limit 429s can specify ~120s) × `riot.max-retries` cannot stall a thread for minutes on stdio. Also adds a test for the previously-uncovered `NumberFormatException` fallback (a non-numeric `Retry-After` → the configured default backoff).
- **`riot-account-core`** — trim whitespace around each Riot ID component: `"Faker # KR1"` now resolves and caches identically to `"Faker#KR1"` (internal game-name spaces are preserved). Avoids a benign-but-wasteful cache miss / downstream 404 from stray whitespace.

## Testing

`./gradlew build` green across all three modules — tests + ArchUnit + JaCoCo + Spotless + `verifyRelease`. New tests:

- `clamps_an_excessive_retry_after_to_the_max_backoff`
- `falls_back_to_the_default_backoff_on_an_unparseable_retry_after`
- `trims_whitespace_around_each_riot_id_component`

Both libraries stay at `0.1.0` (unreleased); the `riot-api-core` changelog notes the new `riot.max-retry-backoff` knob. No `@McpTool` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vx1Xhxz4ScNbEh2KhBKm
