### PR TITLE
fix(eval): drop mcpeval config keys the installed schema forbids

### DIFF
--- a/eval/mcpeval.sse.yaml
+++ b/eval/mcpeval.sse.yaml
@@ -26,13 +26,11 @@ judge:
   provider: anthropic
   model: claude-haiku-4-5-20251001
   min_score: 0.7
-  temperature: 0.0
 
 execution:
   max_concurrency: 1
   timeout_seconds: 300
   retry_failed: false
-  fail_fast: false
 
 reporting:
   formats: ["json", "markdown", "html"]

--- a/eval/mcpeval.stdio.yaml
+++ b/eval/mcpeval.stdio.yaml
@@ -29,13 +29,11 @@ judge:
   provider: anthropic
   model: claude-haiku-4-5-20251001
   min_score: 0.7
-  temperature: 0.0
 
 execution:
   max_concurrency: 1
   timeout_seconds: 300
   retry_failed: false
-  fail_fast: false
 
 reporting:
   formats: ["json", "markdown", "html"]


### PR DESCRIPTION
## Problem

The first live-eval run on `master` (run 29649189389) failed **both** matrix legs identically. It was **not** an eval-assertion failure — `mcp-eval` crashed on **config load**, before any test ran:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for MCPEvalSettings
judge.temperature
  Extra inputs are not permitted [type=extra_forbidden, input_value=0.0]
execution.fail_fast
  Extra inputs are not permitted [type=extra_forbidden, input_value=False]
```

## Root cause

The installed `mcpevals` version validates `mcpeval.yaml` with strict pydantic models (`extra_forbidden`). The real `JudgeConfig` (`provider`, `model`, `min_score`, `max_tokens`, `system_prompt`) has no `temperature`, and `ExecutionConfig` (`max_concurrency`, `timeout_seconds`, `retry_failed`) has no `fail_fast`. Both keys came from the mcp-eval docs sample but aren't in this version's schema, so `load_config()` raised at import time and the CLI exited non-zero on both legs (`Run live evals` has `set +e`, so only `Fail the job on eval failure` surfaced it).

## Fix

Remove `judge.temperature` and `execution.fail_fast` from both `mcpeval.stdio.yaml` and `mcpeval.sse.yaml` (4 lines). Verified against the installed package's actual pydantic models; all remaining keys are schema-valid. Pure config change — no test or workflow logic touched.

Once merged, the next run is the real first exercise of the tools, transports, and canaries against live Riot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)