### PR TITLE
fix(ci): expand mcpeval config vars with envsubst

### DIFF
--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -91,7 +91,11 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RIOT_API_KEY: ${{ secrets.RIOT_DEV_REG_TEST_API_KEY }}
         run: |
-          cp "mcpeval.${{ matrix.transport }}.yaml" mcpeval.yaml
+          # mcp-eval does NOT expand ${VAR} placeholders in the config's
+          # command/args/url/env fields, so we expand them here before it reads
+          # the file. Restricted to our three vars so nothing else is touched.
+          envsubst '${LOL_MCP_JAR} ${RIOT_API_KEY} ${LOL_MCP_SSE_URL}' \
+            < "mcpeval.${{ matrix.transport }}.yaml" > mcpeval.yaml
           set +e
           uv run mcp-eval run tests/ -v \
             --json "test-reports/${{ matrix.transport }}.json" \


### PR DESCRIPTION
## Problem

The run after PR #48 (run 29649470927) got past config load and actually ran the evals, but **both** legs failed with only 4/13 tests passing and **zero tools available** to the agent.

**stdio** log, once per test:
```
Error: Unable to access jarfile ${LOL_MCP_JAR}
...
mcp.shared.exceptions.McpError: Connection closed
Tool Coverage: lol_server — Available Tools: 0 (No tools available)
```

**sse** log:
```
httpcore.UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
  (mcp/client/sse.py, connecting to "${LOL_MCP_SSE_URL}")
```

## Root cause

mcp-eval does **not** expand `${VAR}` placeholders in a server's `command` / `args` / `url` / `env` config. mcp-agent builds the stdio child env as `{**get_default_environment(), **(config.env or {})}` — an allowlist that drops `RIOT_API_KEY`, with the config values passed through un-interpolated. So the literal strings reached the process:

- **stdio:** `java -jar ${LOL_MCP_JAR}` → jarfile not found → server never starts → `Connection closed` → agent sees 0 tools → every tool-requiring test fails on `*_called`. (The 4 "passing" tests are the loose validation rubrics a tool-less agent satisfies.)
- **sse:** literal `${LOL_MCP_SSE_URL}` → httpcore `UnsupportedProtocol`.

Confirmed against the installed `mcp_eval` (no expansion in `config.py`) and `mcp_agent/mcp_connection_manager.py` (`env={**get_default_environment(), **(config.env or {})}`).

## Fix

Pre-expand the three vars with `envsubst` (gettext, preinstalled on ubuntu runners) before mcp-eval reads the config:

```bash
envsubst '${LOL_MCP_JAR} ${RIOT_API_KEY} ${LOL_MCP_SSE_URL}' \
  < "mcpeval.${{ matrix.transport }}.yaml" > mcpeval.yaml
```

Restricted to those three names so nothing else is touched. Verified locally that the substituted YAML stays valid for both transports (jar path + Riot key inline for stdio; `url: "http://localhost:8080/sse"` for sse). Workflow-only change.

## Expectation for the next run

This unblocks the confirmed root cause (server launch / sse connect). The next likely unknowns, if they surface, are whether `/sse` is Spring AI's actual SSE endpoint and whether the live tool evals pass against real Riot — I'll iterate on those from the next run's results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)