### PR TITLE
fix(match): box Participant.bountyLevel so null match data deserializes

### DIFF
--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Participant.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Participant.java
@@ -16,7 +16,10 @@ import lombok.NoArgsConstructor;
 public class Participant {
     private int assists;
     private int baronKills;
-    private int bountyLevel;
+    // Boxed: Riot returns "bountyLevel": null for some real matches, which fails to deserialize
+    // into a primitive int (FAIL_ON_NULL_FOR_PRIMITIVES). See RiotMatchAdapterTest. Read nowhere,
+    // so nullability is invisible to consumers.
+    private Integer bountyLevel;
     private int champExperience;
     private int champLevel;
     private int championId;

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/match/adapter/out/riot/RiotMatchAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/match/adapter/out/riot/RiotMatchAdapterTest.java
@@ -112,6 +112,26 @@ class RiotMatchAdapterTest {
     }
 
     @Test
+    void getMatchById_deserializesNullBountyLevel() {
+        // Riot returns "bountyLevel": null for some real matches. If the DTO field is a
+        // primitive int, Jackson raises MismatchedInputException (FAIL_ON_NULL_FOR_PRIMITIVES)
+        // and the whole match — and any analytics over it — fails to deserialize. The live
+        // eval suite caught this against real match data; frozen fixtures had a non-null value.
+        String bodyWithNullBounty = Fixtures.read("match.json").replace("\"bountyLevel\": 0", "\"bountyLevel\": null");
+        stubFor(get(urlEqualTo("/lol/match/v5/matches/NA1_4600000001"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(bodyWithNullBounty)));
+
+        Match match = adapter.getMatchById(REGION, "NA1_4600000001");
+
+        assertThat(match.getInfo().getParticipants()).hasSize(2);
+        assertThat(match.getInfo().getParticipants().get(0).getBountyLevel()).isNull();
+        assertThat(match.getInfo().getParticipants().get(0).getChampionName()).isEqualTo("Ahri");
+    }
+
+    @Test
     void nonSuccessResponse_mapsToRiotApiException_withStatusPreserved() {
         stubFor(get(urlEqualTo("/lol/match/v5/matches/NA1_MISSING"))
                 .willReturn(aResponse().withStatus(500).withBody("server error")));


### PR DESCRIPTION
## Problem (caught by the live eval)

`test_analytics_invariants` failed on real match data with:
```
Cannot map `null` into type `int` (set DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)
  ... field "bountyLevel" ...  (MismatchedInputException)
```
Riot returns `"bountyLevel": null` for some real matches. `Participant.bountyLevel` was a primitive `int`, so the whole match — and every `lol_analytics_player_matches` call over it — failed to deserialize. The offline WireMock fixture had `bountyLevel: 0`, so the suite never caught it; the live suite, running against real Riot data, did. **This is exactly the class of bug the live harness exists to find.**

## Fix

- Box `Participant.bountyLevel` `int` → `Integer`. It is read nowhere in the codebase (verified), so nullability is invisible to consumers.
- Add a WireMock regression test (`getMatchById_deserializesNullBountyLevel`) that stubs `"bountyLevel": null` and asserts the match still deserializes. It reproduced the failure before the change and passes after.

Offline `./gradlew build` green.

## Note / follow-up

Other primitive numeric fields on `Participant` could hit the same issue against future Riot data. If that recurs, the more systemic fix is to disable `FAIL_ON_NULL_FOR_PRIMITIVES` on the Riot RestClient's Jackson mapper in `riot-api-core` (Jackson's own default), rather than boxing field-by-field. Left out of this PR to keep the change minimal and library-untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)