### PR TITLE
fix(eval+match): apex rubric, LLM cost, key preflight, and Team DTO deserialization

### DIFF
--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -21,55 +21,68 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Gate on the LLM key. Absent -> skip green with an actionable notice.
+      # Preflight both credentials. Either missing/invalid -> skip green with an
+      # actionable notice, never a red run. This keeps an expired Riot dev key (they
+      # expire every 24h) from producing a scary red-X on master, and avoids paying
+      # for a full build + eval run that would only fail on auth.
       # ANTHROPIC_API_KEY is the ONLY LLM credential this workflow reads; it never
       # references CLAUDE_CODE_OAUTH_TOKEN (separate bucket, see ADR-0012).
-      - name: Check for ANTHROPIC_API_KEY
-        id: keycheck
+      - name: Preflight — verify keys
+        id: preflight
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RIOT_API_KEY: ${{ secrets.RIOT_DEV_REG_TEST_API_KEY }}
         run: |
           if [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "::notice title=Live evals skipped::ANTHROPIC_API_KEY is not set. Add it as a repository secret to enable the live mcp-eval suite. (This is separate from CLAUDE_CODE_OAUTH_TOKEN, which is not used here.)"
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
+          # Probe Riot key validity with a cheap, parameter-free status call. Riot dev
+          # keys expire every 24h; an expired key makes every live-data test fail on auth.
+          code="$(curl -s -o /dev/null -w '%{http_code}' -H "X-Riot-Token: $RIOT_API_KEY" https://na1.api.riotgames.com/lol/status/v4/platform-data || echo 000)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::notice title=Live evals skipped::Riot API key is invalid or expired (HTTP $code). Regenerate the dev key on the Riot developer portal and update the RIOT_DEV_REG_TEST_API_KEY secret — dev keys expire every 24 hours."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::warning title=Riot key probe inconclusive::status probe returned HTTP $code; proceeding with the eval run anyway."
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 21
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'zulu'
 
       - name: Setup Gradle
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Build server jar
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         run: ./gradlew :lol-mcp-server:bootJar
 
       - name: Resolve jar path
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         run: |
           JAR="$(ls lol-mcp-server/build/libs/lol-mcp-server-*.jar | grep -v plain | head -n1)"
           echo "LOL_MCP_JAR=$GITHUB_WORKSPACE/$JAR" >> "$GITHUB_ENV"
 
       - name: Set up uv
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.11'
 
       - name: Install harness
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         working-directory: eval
         run: uv sync
 
       - name: Start SSE server
-        if: steps.keycheck.outputs.run == 'true' && matrix.transport == 'sse'
+        if: steps.preflight.outputs.run == 'true' && matrix.transport == 'sse'
         env:
           RIOT_API_KEY: ${{ secrets.RIOT_DEV_REG_TEST_API_KEY }}
         run: |
@@ -85,7 +98,7 @@ jobs:
           done
 
       - name: Run live evals
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         working-directory: eval
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -105,7 +118,7 @@ jobs:
           set -e
 
       - name: Summarize outcome
-        if: steps.keycheck.outputs.run == 'true' && always()
+        if: steps.preflight.outputs.run == 'true' && always()
         working-directory: eval
         run: |
           {
@@ -122,7 +135,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload reports
-        if: steps.keycheck.outputs.run == 'true' && always()
+        if: steps.preflight.outputs.run == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: mcpeval-reports-${{ matrix.transport }}
@@ -134,7 +147,7 @@ jobs:
         run: kill "$SSE_PID" || true
 
       - name: Fail the job on eval failure
-        if: steps.keycheck.outputs.run == 'true'
+        if: steps.preflight.outputs.run == 'true'
         run: |
           if [ "${EVAL_EXIT:-1}" != "0" ]; then
             echo "Live evals failed — see the job summary and artifact."

--- a/eval/mcpeval.sse.yaml
+++ b/eval/mcpeval.sse.yaml
@@ -16,10 +16,11 @@ agents:
       instruction: |
         You are a precise QA agent for a League of Legends MCP server.
         Use the provided tools to answer. Prefer NA1 as the platform and
-        AMERICAS as the region unless told otherwise. When a lookup fails,
-        report the failure plainly instead of inventing data.
+        AMERICAS as the region unless told otherwise. If a tool call returns
+        an error, do NOT retry it — report the failure plainly and stop,
+        rather than inventing data or calling it repeatedly.
       server_names: ["lol_server"]
-      max_iterations: 6
+      max_iterations: 4
 default_agent: riot_tester
 
 judge:

--- a/eval/mcpeval.stdio.yaml
+++ b/eval/mcpeval.stdio.yaml
@@ -19,10 +19,11 @@ agents:
       instruction: |
         You are a precise QA agent for a League of Legends MCP server.
         Use the provided tools to answer. Prefer NA1 as the platform and
-        AMERICAS as the region unless told otherwise. When a lookup fails,
-        report the failure plainly instead of inventing data.
+        AMERICAS as the region unless told otherwise. If a tool call returns
+        an error, do NOT retry it — report the failure plainly and stop,
+        rather than inventing data or calling it repeatedly.
       server_names: ["lol_server"]
-      max_iterations: 6
+      max_iterations: 4
 default_agent: riot_tester
 
 judge:

--- a/eval/tests/test_league.py
+++ b/eval/tests/test_league.py
@@ -18,8 +18,11 @@ async def test_apex_challenger(agent, session):
         Expect.judge.llm(
             rubric=(
                 "The answer reports a CHALLENGER league with a non-zero number "
-                "of entries and names at least one player. It does not report an "
-                "error or an empty league."
+                "of entries and identifies at least one entry in it. A PUUID, "
+                "summoner id, or LP/rank is sufficient identification — Riot no "
+                "longer exposes human-readable summoner names in league entries, "
+                "so do not require a display name. It does not report an error or "
+                "an empty league."
             ),
             min_score=0.7,
         ),

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Ban.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Ban.java
@@ -1,13 +1,17 @@
 package com.muddl.riot.lol.match.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents a champion ban in champion select phase.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Ban {
     private int championId;
     private int pickTurn;

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/ObjectiveDetails.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/ObjectiveDetails.java
@@ -1,13 +1,17 @@
 package com.muddl.riot.lol.match.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents details of a specific objective type in a League of Legends match.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ObjectiveDetails {
     private boolean first;
     private int kills;

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Objectives.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Objectives.java
@@ -1,13 +1,17 @@
 package com.muddl.riot.lol.match.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents objectives taken by a team in a League of Legends match.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Objectives {
     private ObjectiveDetails baron;
     private ObjectiveDetails champion;

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Team.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/match/domain/Team.java
@@ -1,14 +1,18 @@
 package com.muddl.riot.lol.match.domain;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents a team in a League of Legends match.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Team {
     private List<Ban> bans;
     private Objectives objectives;

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/match/adapter/out/riot/RiotMatchAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/match/adapter/out/riot/RiotMatchAdapterTest.java
@@ -107,6 +107,17 @@ class RiotMatchAdapterTest {
         assertThat(match.getInfo().getParticipants()).hasSize(2);
         assertThat(match.getInfo().getParticipants().get(0).getChampionName()).isEqualTo("Ahri");
         assertThat(match.getInfo().getParticipants().get(0).isWin()).isTrue();
+
+        // The team subtree (Team/Ban/Objectives/ObjectiveDetails) must deserialize from a populated
+        // teams array. These DTOs previously lacked @NoArgsConstructor/@AllArgsConstructor, so Jackson
+        // could not build them ("cannot deserialize from Object value, no Creator") — the live
+        // analytics eval caught it against real match data; this fixture's teams array used to be empty.
+        assertThat(match.getInfo().getTeams()).hasSize(2);
+        assertThat(match.getInfo().getTeams().get(0).getTeamId()).isEqualTo(100);
+        assertThat(match.getInfo().getTeams().get(0).isWin()).isTrue();
+        assertThat(match.getInfo().getTeams().get(0).getBans()).hasSize(2);
+        assertThat(match.getInfo().getTeams().get(0).getObjectives().getBaron().getKills())
+                .isEqualTo(1);
         verify(getRequestedFor(urlEqualTo("/lol/match/v5/matches/NA1_4600000001"))
                 .withHeader("X-RIOT-TOKEN", equalTo("test-key-123")));
     }

--- a/lol-mcp-server/src/test/resources/fixtures/match.json
+++ b/lol-mcp-server/src/test/resources/fixtures/match.json
@@ -217,6 +217,38 @@
         "win": false
       }
     ],
-    "teams": []
+    "teams": [
+      {
+        "teamId": 100,
+        "win": true,
+        "bans": [
+          { "championId": 105, "pickTurn": 1 },
+          { "championId": 51, "pickTurn": 2 }
+        ],
+        "objectives": {
+          "baron": { "first": true, "kills": 1 },
+          "champion": { "first": true, "kills": 30 },
+          "dragon": { "first": false, "kills": 3 },
+          "inhibitor": { "first": true, "kills": 2 },
+          "riftHerald": { "first": true, "kills": 1 },
+          "tower": { "first": true, "kills": 8 }
+        }
+      },
+      {
+        "teamId": 200,
+        "win": false,
+        "bans": [
+          { "championId": 63, "pickTurn": 3 }
+        ],
+        "objectives": {
+          "baron": { "first": false, "kills": 0 },
+          "champion": { "first": false, "kills": 20 },
+          "dragon": { "first": true, "kills": 1 },
+          "inhibitor": { "first": false, "kills": 0 },
+          "riftHerald": { "first": false, "kills": 0 },
+          "tower": { "first": false, "kills": 2 }
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
Four fixes from the run-3 and bounty-merge-run diagnoses. **Now includes a production match-DTO fix** (folded in per request to keep run-found fixes in the open PR).

## 1. Team subtree DTO deserialization (production — analytics fix)
The bounty-merge run surfaced a *second* match-DTO failure: `cannot deserialize from Object value (no delegate- or property-based Creator)` through `Match → MatchInfo → Team`. `Team`, `Ban`, `Objectives`, `ObjectiveDetails` had only `@Data @Builder` — missing `@NoArgsConstructor`/`@AllArgsConstructor` (the documented nested-`@Builder` gotcha), while every other match DTO had all four. The offline fixture's `teams` array was **empty**, so no test ever built the subtree.
- Add the two annotations to the four classes.
- Populate the fixture's `teams` with two real teams (bans + objectives) and assert the subtree deserializes. Offline `./gradlew build` green.

## 2. Apex rubric (`test_apex_challenger`)
Accept a PUUID / summoner id / LP-rank as identifying an entry — Riot no longer exposes summoner names in league entries, so "names at least one player" was unsatisfiable.

## 3. LLM cost pass
`max_iterations` 6 → 4; instruct the agent not to retry a failed tool call (kills the retry-spam seen in the logs). The key preflight below also skips the whole build+eval when the key is dead.

## 4. Expired-key preflight resilience
A preflight probes Riot key validity via a cheap `lol/status/v4/platform-data` call; an invalid/expired key (dev keys expire every 24h) skips green with an actionable notice instead of a red run. Same treatment as a missing `ANTHROPIC_API_KEY`; still never reads `CLAUDE_CODE_OAUTH_TOKEN`.

## Still open (not in this PR)
**Featured-games 403** — confirmed a *real* endpoint bug (fails with the fresh key while everything else authenticates). Held for a path decision rather than guessing on production spectator code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)