### PR TITLE
fix(lol): null-safe champion DTOs + steer analytics eval (1b live-eval failures)

### DIFF
--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -176,3 +176,18 @@ fields need an explicit `@JsonProperty("incident_severity")` on the camelCase Ja
 deserialize to `null` silently — the adapter's WireMock test asserts the parsed value to catch it.
 Seen in `status`'s `StatusEntry` (sub-project 1b). Do not switch on a global naming strategy for one
 context; annotate the specific fields.
+
+## Riot DTO number/boolean fields must be **boxed**, not primitives
+
+Riot returns `null` for fields tied to systems it has retired, and a Java **primitive** field then
+throws at deserialization: `Cannot map null into type int/boolean/long`
+(`FAIL_ON_NULL_FOR_PRIMITIVES`). The live eval caught two in sub-project 1b — Champion-Mastery-V4's
+`chestGranted` (and `tokensEarned`) went null after the 2024 mastery/chest revamp, and Champion-V3's
+`maxNewPlayerLevel` came back null — both had been declared `boolean`/`int`. Offline WireMock tests
+pass because our fixtures were fully populated; only live data has the nulls.
+
+**Rule:** declare Riot DTO number/boolean fields as boxed wrappers (`Integer`/`Long`/`Boolean`), not
+primitives. `String`s and `List`s are already null-safe. When you add a DTO, also add a WireMock case
+that feeds `null` for the nullable-looking fields and asserts it parses — that reproduces this class
+of failure offline instead of waiting for the post-merge live eval. Boxing `boolean`→`Boolean` also
+renames the Lombok getter (`isX()` → `getX()`); update call sites.

--- a/eval/tests/test_analytics.py
+++ b/eval/tests/test_analytics.py
@@ -6,11 +6,15 @@ from mcp_eval import task, Expect
 
 @task("Analytics returns coherent aggregates for a discovered player")
 async def test_analytics_invariants(agent, session):
+    # Steer explicitly to the composite analytics tool. Sub-project 1b added granular match tools
+    # (lol_match_ids_by_player + lol_match_by_id); left unsteered, the agent assembles the analysis
+    # from those and never calls lol_analytics_player_matches, so this eval must name the tool it is
+    # here to exercise.
     response = await agent.generate_str(
         "Get the CHALLENGER apex league for RANKED_SOLO_5x5 on NA1, pick any one "
-        "player, then analyze that player's 5 most recent matches on platform NA1 "
-        "and region AMERICAS. Report their average KDA and win rate as a "
-        "percentage."
+        "player, then use the analytics tool (lol_analytics_player_matches) to "
+        "analyze that player's 5 most recent matches on platform NA1 and region "
+        "AMERICAS. Report their average KDA and win rate as a percentage."
     )
     await session.assert_that(
         Expect.tools.was_called("lol_analytics_player_matches"),

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/champion/domain/ChampionRotation.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/champion/domain/ChampionRotation.java
@@ -16,5 +16,7 @@ import lombok.NoArgsConstructor;
 public class ChampionRotation {
     private List<Integer> freeChampionIds;
     private List<Integer> freeChampionIdsForNewPlayers;
-    private int maxNewPlayerLevel;
+    // Boxed: Riot returns this as null in some responses, and a primitive int fails deserialization
+    // ("Cannot map null into type int"). The live eval caught it — see gotchas.md.
+    private Integer maxNewPlayerLevel;
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/championmastery/domain/ChampionMastery.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/championmastery/domain/ChampionMastery.java
@@ -13,13 +13,18 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChampionMastery {
+    // Boxed types throughout: Riot returns null for fields tied to systems it has retired — notably
+    // chestGranted and tokensEarned after the 2024 mastery/chest revamp — and a primitive fails
+    // deserialization ("Cannot map null into type boolean/int"). The live eval caught chestGranted;
+    // the rest are boxed defensively so a future null on the revamped mastery shape can't recur. See
+    // gotchas.md.
     private String puuid;
-    private long championId;
-    private int championLevel;
-    private int championPoints;
-    private long lastPlayTime;
-    private long championPointsSinceLastLevel;
-    private long championPointsUntilNextLevel;
-    private boolean chestGranted;
-    private int tokensEarned;
+    private Long championId;
+    private Integer championLevel;
+    private Integer championPoints;
+    private Long lastPlayTime;
+    private Long championPointsSinceLastLevel;
+    private Long championPointsUntilNextLevel;
+    private Boolean chestGranted;
+    private Integer tokensEarned;
 }

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/champion/adapter/out/riot/RiotChampionAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/champion/adapter/out/riot/RiotChampionAdapterTest.java
@@ -67,6 +67,25 @@ class RiotChampionAdapterTest {
     }
 
     @Test
+    void getChampionRotation_nullMaxNewPlayerLevel_parsesWithoutError() {
+        // Regression for the live-eval failure: Riot returned maxNewPlayerLevel as null and a
+        // primitive int threw "Cannot map null into type int". The boxed field must tolerate it.
+        stubFor(
+                get(urlEqualTo(ROTATION_URL))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(
+                                                "{\"freeChampionIds\":[1,2],\"freeChampionIdsForNewPlayers\":[3],\"maxNewPlayerLevel\":null}")));
+
+        ChampionRotation rotation = adapter.getChampionRotation(PLATFORM);
+
+        assertThat(rotation.getMaxNewPlayerLevel()).isNull();
+        assertThat(rotation.getFreeChampionIds()).containsExactly(1, 2);
+    }
+
+    @Test
     void nonSuccessResponse_mapsToRiotApiException_withStatusPreserved() {
         stubFor(get(urlEqualTo(ROTATION_URL))
                 .willReturn(aResponse().withStatus(403).withBody("forbidden")));

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/adapter/in/mcp/ChampionMasteryToolTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/adapter/in/mcp/ChampionMasteryToolTest.java
@@ -28,7 +28,7 @@ class ChampionMasteryToolTest {
 
     @Test
     void getMasteryByPlayer_passesArgsThrough_withNullCount() {
-        ChampionMastery m = ChampionMastery.builder().championId(157).build();
+        ChampionMastery m = ChampionMastery.builder().championId(157L).build();
         when(mockService.getMasteryByPlayer(PLATFORM, "Faker#KR1", null)).thenReturn(List.of(m));
 
         assertThat(tool.getMasteryByPlayer("NA1", "Faker#KR1", null)).containsExactly(m);

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/adapter/out/riot/RiotChampionMasteryAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/adapter/out/riot/RiotChampionMasteryAdapterTest.java
@@ -97,6 +97,28 @@ class RiotChampionMasteryAdapterTest {
     }
 
     @Test
+    void getMasteryByPuuid_nullRetiredPrimitives_parseWithoutError() {
+        // Regression for the live-eval failure: Riot's 2024 mastery/chest revamp returns chestGranted
+        // (and other retired-system fields) as null; a primitive boolean/int threw "Cannot map null
+        // into type ...". The boxed fields must tolerate null while the core fields still parse.
+        stubFor(get(urlEqualTo(ALL_URL))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"puuid\":\"" + PUUID + "\",\"championId\":157,\"championLevel\":7,"
+                                + "\"championPoints\":123456,\"lastPlayTime\":1609459200000,"
+                                + "\"championPointsSinceLastLevel\":null,\"championPointsUntilNextLevel\":null,"
+                                + "\"chestGranted\":null,\"tokensEarned\":null}]")));
+
+        List<ChampionMastery> masteries = adapter.getMasteryByPuuid(PLATFORM, PUUID, null);
+
+        assertThat(masteries).hasSize(1);
+        assertThat(masteries.get(0).getChestGranted()).isNull();
+        assertThat(masteries.get(0).getTokensEarned()).isNull();
+        assertThat(masteries.get(0).getChampionPoints()).isEqualTo(123456);
+    }
+
+    @Test
     void nonSuccessResponse_mapsToRiotApiException_withStatusPreserved() {
         stubFor(get(urlEqualTo(ALL_URL)).willReturn(aResponse().withStatus(404).withBody("not found")));
 

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/application/ChampionMasteryServiceTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/championmastery/application/ChampionMasteryServiceTest.java
@@ -22,9 +22,9 @@ class ChampionMasteryServiceTest {
     void getMasteryByPlayer_resolvesPlayer_thenReturnsAll() {
         when(resolver.resolvePuuid("Faker#KR1")).thenReturn("faker-puuid");
         ChampionMastery m1 =
-                ChampionMastery.builder().championId(157).championPoints(999).build();
+                ChampionMastery.builder().championId(157L).championPoints(999).build();
         ChampionMastery m2 =
-                ChampionMastery.builder().championId(64).championPoints(500).build();
+                ChampionMastery.builder().championId(64L).championPoints(500).build();
         port.put("faker-puuid", List.of(m1, m2));
 
         assertThat(service.getMasteryByPlayer(PLATFORM, "Faker#KR1", null)).containsExactly(m1, m2);
@@ -33,8 +33,8 @@ class ChampionMasteryServiceTest {
     @Test
     void getMasteryByPlayer_honoursCount() {
         when(resolver.resolvePuuid("puuid-raw")).thenReturn("puuid-raw");
-        ChampionMastery m1 = ChampionMastery.builder().championId(157).build();
-        ChampionMastery m2 = ChampionMastery.builder().championId(64).build();
+        ChampionMastery m1 = ChampionMastery.builder().championId(157L).build();
+        ChampionMastery m2 = ChampionMastery.builder().championId(64L).build();
         port.put("puuid-raw", List.of(m1, m2));
 
         assertThat(service.getMasteryByPlayer(PLATFORM, "puuid-raw", 1)).containsExactly(m1);


### PR DESCRIPTION
## Fix: 1b live-eval failures (run #29672910078)

The post-merge live eval failed 3/18 on both transports. Two independent root causes, grouped here per the one-PR-per-eval-run policy.

### 1. Null-primitive deserialization crash (real bug)

`lol_champion_rotation` and `lol_champion_mastery_by_player` both threw `Cannot map null into type ...` against live Riot data:

| Field | DTO | Why null |
|---|---|---|
| `chestGranted` (`boolean`) | `ChampionMastery` | Hextech chests removed in the 2024 mastery revamp — now always null |
| `maxNewPlayerLevel` (`int`) | `ChampionRotation` | Riot returns it null |

Jackson's `FAIL_ON_NULL_FOR_PRIMITIVES` rejects null → primitive. Offline WireMock tests passed only because our fixtures were fully populated.

**Fix:** box the affected DTO fields to wrappers (`Integer`/`Long`/`Boolean`). All of `ChampionMastery`'s numerics are boxed defensively so another retired-system field can't recur (Jackson fails on the *first* null primitive, so a one-field fix risks a fix-one-reveal-the-next cascade). Added WireMock cases that feed `null` and assert clean parsing — **this class of failure is now caught offline** instead of post-merge. Recorded in `gotchas.md`.

### 2. Analytics eval no longer called its tool (eval steer)

`test_analytics` asserts `lol_analytics_player_matches` is called, but 1b added `lol_match_ids_by_player` + `lol_match_by_id` — so the agent now assembles the analysis from the granular tools and never calls the composite one. The substance check (`analytics_invariants_hold`) still passed; only `analytics_called` failed. **Fix:** steer the prompt to name the analytics tool, restoring the eval's intent.

### Verification

- Offline `./gradlew build` green (unit + ArchUnit + JaCoCo + Spotless + verifyRelease + verifyModuleDocs).
- The two new regression tests fail before the DTO change, pass after.
- The live green-run over both transports is confirmed post-merge by the next `live-eval` run.

Part of the not-yet-tagged `lol-mcp-server` 0.2.0 (folds into it; no version change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt
