### PR TITLE
fix(lol): challenges null-long + champion live sr/newplayer shape (run 2 live-eval failures)

### DIFF
--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -191,3 +191,15 @@ primitives. `String`s and `List`s are already null-safe. When you add a DTO, als
 that feeds `null` for the nullable-looking fields and asserts it parses — that reproduces this class
 of failure offline instead of waiting for the post-merge live eval. Boxing `boolean`→`Boolean` also
 renames the Lombok getter (`isX()` → `getX()`); update call sites.
+
+## Riot's live JSON field names can differ from the developer-portal docs
+
+Champion-V3 `/lol/platform/v3/champion-rotations` is documented as returning `freeChampionIds`,
+`freeChampionIdsForNewPlayers`, `maxNewPlayerLevel` — but the **live** endpoint returns the compact
+keys `sr` and `newplayer` (and no `maxNewPlayerLevel`). Riot appears to serve both shapes. A DTO
+written to the documented names deserialized to all-null against live data (with
+`@JsonIgnoreProperties(ignoreUnknown = true)` the real keys were silently dropped), and the offline
+WireMock test passed only because its fixture had encoded the documented shape. The live eval caught
+it. **Lesson:** confirm field names against a real response (`curl` with a key), not just the portal
+schema; when both shapes exist, accept them with `@JsonAlias`. This is the concrete case behind the
+standing "verify against the live developer portal, never assume" constraint.

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengePoints.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengePoints.java
@@ -13,8 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChallengePoints {
+    // Boxed numerics: Riot returns null for these on categories a player has no progress in, and a
+    // primitive double fails deserialization ("Cannot map null into type double"). See gotchas.md.
     private String level;
-    private double current;
-    private double max;
-    private double percentile;
+    private Double current;
+    private Double max;
+    private Double percentile;
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengeProgress.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengeProgress.java
@@ -13,9 +13,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChallengeProgress {
-    private long challengeId;
+    // Boxed numerics: Riot returns null for these on challenges a player has not progressed on or
+    // achieved (notably achievedTime), and a primitive long/double fails deserialization
+    // ("Cannot map null into type long"). The live eval caught achievedTime. See gotchas.md.
+    private Long challengeId;
     private String level;
-    private double value;
-    private double percentile;
-    private long achievedTime;
+    private Double value;
+    private Double percentile;
+    private Long achievedTime;
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/champion/domain/ChampionRotation.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/champion/domain/ChampionRotation.java
@@ -1,5 +1,6 @@
 package com.muddl.riot.lol.champion.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,9 +15,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChampionRotation {
+    // The live Champion-V3 endpoint returns the compact keys `sr` / `newplayer`, NOT the
+    // developer-portal-documented `freeChampionIds` / `freeChampionIdsForNewPlayers`. The live eval
+    // caught this (our fixture had encoded the documented shape). @JsonAlias accepts both so either
+    // shape maps — see gotchas.md.
+    @JsonAlias("sr")
     private List<Integer> freeChampionIds;
+
+    @JsonAlias("newplayer")
     private List<Integer> freeChampionIdsForNewPlayers;
-    // Boxed: Riot returns this as null in some responses, and a primitive int fails deserialization
-    // ("Cannot map null into type int"). The live eval caught it — see gotchas.md.
+
+    // Absent from the live compact shape; present (sometimes null) in the documented shape. Boxed so
+    // both "absent" and "present null" deserialize cleanly.
     private Integer maxNewPlayerLevel;
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/status/domain/StatusEntry.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/status/domain/StatusEntry.java
@@ -15,7 +15,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StatusEntry {
-    private long id;
+    // Boxed defensively: Riot number fields can come back null, and a primitive long fails
+    // deserialization ("Cannot map null into type long"). See gotchas.md.
+    private Long id;
 
     @JsonProperty("maintenance_status")
     private String maintenanceStatus;

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/adapter/out/riot/RiotChallengesAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/adapter/out/riot/RiotChallengesAdapterTest.java
@@ -71,6 +71,28 @@ class RiotChallengesAdapterTest {
     }
 
     @Test
+    void getPlayerDataByPuuid_nullNumericsOnUnachievedChallenge_parseWithoutError() {
+        // Regression for the live-eval failure: Riot returns null for a challenge's numerics (notably
+        // achievedTime) when the player has not achieved it; a primitive long/double threw "Cannot map
+        // null into type long". The boxed fields must tolerate null while the rest still parse.
+        stubFor(get(urlEqualTo(URL))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"totalPoints\":{\"level\":\"NONE\",\"current\":null,\"max\":null,"
+                                + "\"percentile\":null},\"categoryPoints\":{},\"challenges\":[{\"challengeId\":101101,"
+                                + "\"level\":\"NONE\",\"value\":null,\"percentile\":null,\"achievedTime\":null}]}")));
+
+        ChallengesPlayerData data = adapter.getPlayerDataByPuuid(PLATFORM, PUUID);
+
+        assertThat(data.getTotalPoints().getCurrent()).isNull();
+        assertThat(data.getChallenges()).hasSize(1);
+        assertThat(data.getChallenges().get(0).getChallengeId()).isEqualTo(101101L);
+        assertThat(data.getChallenges().get(0).getAchievedTime()).isNull();
+        assertThat(data.getChallenges().get(0).getValue()).isNull();
+    }
+
+    @Test
     void nonSuccessResponse_mapsToRiotApiException_withStatusPreserved() {
         stubFor(get(urlEqualTo(URL)).willReturn(aResponse().withStatus(404).withBody("not found")));
 

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/champion/adapter/out/riot/RiotChampionAdapterTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/champion/adapter/out/riot/RiotChampionAdapterTest.java
@@ -60,10 +60,28 @@ class RiotChampionAdapterTest {
 
         ChampionRotation rotation = adapter.getChampionRotation(PLATFORM);
 
-        assertThat(rotation.getMaxNewPlayerLevel()).isEqualTo(10);
-        assertThat(rotation.getFreeChampionIds()).containsExactly(1, 15, 22);
+        // Live Champion-V3 shape: `sr` / `newplayer`, no maxNewPlayerLevel. @JsonAlias maps them.
+        assertThat(rotation.getFreeChampionIds()).containsExactly(29, 30, 40);
         assertThat(rotation.getFreeChampionIdsForNewPlayers()).containsExactly(18, 81, 92);
+        assertThat(rotation.getMaxNewPlayerLevel()).isNull();
         verify(getRequestedFor(urlEqualTo(ROTATION_URL)).withHeader("X-RIOT-TOKEN", equalTo("test-key-123")));
+    }
+
+    @Test
+    void getChampionRotation_legacyDocumentedShape_stillParsesViaJsonAlias() {
+        // The developer-portal-documented shape (freeChampionIds / maxNewPlayerLevel). Riot appears to
+        // serve both, so the primary field names must still map.
+        stubFor(get(urlEqualTo(ROTATION_URL))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"freeChampionIds\":[1,15,22],\"freeChampionIdsForNewPlayers\":[18,81,92],"
+                                + "\"maxNewPlayerLevel\":10}")));
+
+        ChampionRotation rotation = adapter.getChampionRotation(PLATFORM);
+
+        assertThat(rotation.getFreeChampionIds()).containsExactly(1, 15, 22);
+        assertThat(rotation.getMaxNewPlayerLevel()).isEqualTo(10);
     }
 
     @Test

--- a/lol-mcp-server/src/test/resources/fixtures/champion-rotation.json
+++ b/lol-mcp-server/src/test/resources/fixtures/champion-rotation.json
@@ -1,5 +1,4 @@
 {
-  "freeChampionIds": [1, 15, 22],
-  "freeChampionIdsForNewPlayers": [18, 81, 92],
-  "maxNewPlayerLevel": 10
+  "sr": [29, 30, 40],
+  "newplayer": [18, 81, 92]
 }


### PR DESCRIPTION
## Fix: 1b live-eval failures (run #29673340547)

Second post-merge live-eval run went 16/18 (up from 15/18 — PR #54 fixed champion_mastery + analytics). Two remaining failures, both grouped here per the one-PR-per-run policy. Both trace to the same theme: **our DTOs were written against Riot's documented shapes, but live Riot differs** — the exact hazard the standing "verify against the live developer portal, never assume" constraint exists for.

### 1. `challenges` — null primitive (real bug)

`ChallengesPlayerData` crashed with `Cannot map null into type long`: an **un-achieved** challenge returns `achievedTime: null` (and other numerics null). Run 1 passed only because that run's discovered player had achieved values. **Fix:** box the `ChallengePoints` / `ChallengeProgress` numerics; box `StatusEntry.id` defensively so no remaining 1b DTO primitive can hit this class. Added a WireMock regression that feeds nulls.

### 2. `champion_rotation` — wrong field names (real bug)

The tool returned an all-null rotation. A `curl` with a live key showed **why**: the live Champion-V3 endpoint returns
```json
{"sr":[29,30,40,...],"newplayer":[17,18,33,...]}
```
— **not** the documented `freeChampionIds` / `freeChampionIdsForNewPlayers` / `maxNewPlayerLevel`. Our DTO used the documented names, so `@JsonIgnoreProperties(ignoreUnknown = true)` silently dropped the real `sr`/`newplayer` arrays → all-null. The offline fixture had encoded the documented shape, so offline passed while live failed. (Run 1's crash-on-`maxNewPlayerLevel` vs run 2's all-null suggests Riot serves both shapes.)

**Fix:** `@JsonAlias("sr")` / `@JsonAlias("newplayer")` so both the live compact shape and the documented shape map; `maxNewPlayerLevel` stays boxed (absent live, present-null in the docs shape). Fixture updated to the **real** shape; a legacy-shape test proves the alias still accepts the documented names.

### Verification & durable record

- Offline `./gradlew build` green (all gates).
- New WireMock cases reproduce both live failures offline, so this class is now caught pre-merge.
- `gotchas.md`: two entries — box Riot numeric/boolean fields; and confirm live field names by `curl`, accepting divergent shapes with `@JsonAlias`.
- Part of the not-yet-tagged `lol-mcp-server` 0.2.0 (no version change).

The live green-run over both transports is confirmed by the next `live-eval` run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt
