### PR TITLE
chore: housekeeping skill + Claude Code Actions fix

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -33,7 +33,7 @@ Work through each item. For every finding, note the file, the drift, and the fix
    - Context/package names and transport details (`stdio`/`sse`) match the source tree.
 2. **KB integrity.**
    - Every ADR on disk is linked from `docs/knowledge/README.md`:
-     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)`
+     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'decisions/ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sed 's|decisions/||' | sort -u)`
    - ADR numbering is contiguous; superseded ADRs carry `Superseded by ADR-00NN`.
    - Every relative Markdown link resolves (no dead targets) across `docs/knowledge/` and root docs.
 3. **Roadmap freshness.** `roadmap.md` status table matches reality; dates are absolute (not "last

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: housekeeping
+description: Audit and trim the repo's docs, knowledge base, roadmap, skills, and agents so they stay accurate and fit-for-purpose. Use for a periodic maintenance pass, or when doc drift is suspected. Accepts `--audit-only` to report without editing.
+---
+
+# Repository housekeeping
+
+Keep `riot-api-mcp-server`'s durable context — docs, knowledge base, roadmap, skills, agents —
+accurate, trim, and consistent with the real project. This is the reusable definition behind both
+the manual `/housekeeping` pass and the weekly `housekeeping.yml` Action.
+
+## Modes
+
+- **`--audit-only`** — report findings as a checklist; make no edits.
+- **default** — apply the fixes, keeping each change small and single-purpose.
+
+## Hydrate first
+
+Read `docs/knowledge/README.md` (the hydrate/persist protocol), then `roadmap.md` and `gotchas.md`,
+so fixes stay consistent with recorded decisions. For any non-trivial doc rewrite, delegate the
+prose to the `docs-maintainer` agent rather than restating its rules here.
+
+## Audit checklist
+
+Work through each item. For every finding, note the file, the drift, and the fix.
+
+1. **Doc ↔ code drift.** Re-derive facts from source and reconcile prose in `README.md`,
+   `ARCHITECTURE.md`, `CLAUDE.md`, `CONTRIBUTING.md`:
+   - Tool count = unique `name = "…"` values:
+     `grep -rhoE 'name = "[a-z_]+"' --include=*.java lol-mcp-server/src/main | sort -u | wc -l`
+   - Tool classes = files declaring `@McpTool` under `adapter/in/mcp`:
+     `grep -rl "@McpTool" --include=*.java lol-mcp-server/src/main | grep 'adapter/in/mcp' | wc -l`
+   - Context/package names and transport details (`stdio`/`sse`) match the source tree.
+2. **KB integrity.**
+   - Every ADR on disk is linked from `docs/knowledge/README.md`:
+     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)`
+   - ADR numbering is contiguous; superseded ADRs carry `Superseded by ADR-00NN`.
+   - Every relative Markdown link resolves (no dead targets) across `docs/knowledge/` and root docs.
+3. **Roadmap freshness.** `roadmap.md` status table matches reality; dates are absolute (not "last
+   week"); deferred items are still true.
+4. **Skills & agents fit-for-purpose.** Each `.claude/skills/*/SKILL.md` and `.claude/agents/*.md`
+   references real files, commands, and tool names; descriptions are accurate; nothing is stale or
+   duplicated.
+5. **CHANGELOG ↔ versions.** Module versions and `CHANGELOG.md` entries are consistent.
+
+## Hands-off (never touch)
+
+`docs/superpowers/specs/` and `docs/superpowers/plans/` are dated snapshots — immutable history.
+Do not edit or trim them. Scope moves in `roadmap.md`, not in the dated specs.
+
+## Finishing
+
+- **`--audit-only`:** print the findings checklist and stop.
+- **default:** apply fixes, then persist per `docs/knowledge/README.md` — a new pitfall goes to
+  `gotchas.md`, a new decision becomes an ADR (and is linked from the KB README). Do not commit or
+  open a PR yourself; the caller (human or workflow) owns git.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,28 +3,16 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write   # REQUIRED to post reviews/comments (was `read` — the no-op cause)
       id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,13 +20,26 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
+            Review this pull request for a Spring Boot 4 / Spring AI MCP server (Java 21,
+            bounded-context hexagonal architecture). Focus on:
+            - Correctness and potential bugs, especially null-safety in Riot DTOs and error mapping.
+            - Hexagonal boundary violations: adapter -> application -> domain (inward only);
+              @McpTool only in adapter.in.mcp; RestClient only in adapter.out.riot.
+            - Test coverage: WireMock for outbound adapters, in-memory port fakes for services.
+            - Security: RIOT_API_KEY must never be logged or hard-coded.
+
+            The PR branch is already checked out in the working directory.
+
+            Use `gh pr comment` for top-level summary feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for
+            specific line-level issues.
+            Only post GitHub comments — do not submit review text as chat messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write   # post review comments when @claude-mentioned on a PR
+      issues: write          # respond on issues when @claude-mentioned
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,75 @@
+name: Weekly Housekeeping
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:        # manual runs always proceed (bypass the commit gate)
+
+# Least-privilege; elevate only where needed.
+permissions:
+  contents: read
+
+jobs:
+  housekeeping:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create the housekeeping branch
+      pull-requests: write   # open the PR
+      id-token: write
+    steps:
+      - name: Checkout (full history for the commit gate)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Gate: on a scheduled run, proceed only if commits landed in the last week.
+      # Manual (workflow_dispatch) runs always proceed.
+      - name: Commit gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          COUNT="$(git rev-list --count --since='1 week ago' HEAD)"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Housekeeping::$COUNT commit(s) in the last week — running."
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Housekeeping skipped::No commits in the last week."
+          fi
+
+      - name: Run housekeeping skill (apply mode, edits only)
+        if: steps.gate.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Run the housekeeping skill to audit and fix drift in this repo's docs, knowledge base,
+            roadmap, skills, and agents. Apply the fixes to the working tree. Do NOT commit, push,
+            or open a pull request — a later workflow step owns all git operations. Never edit
+            anything under docs/superpowers/specs/ or docs/superpowers/plans/ (immutable history).
+          claude_args: |
+            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(grep:*),Bash(ls:*),Bash(comm:*),Bash(git status:*),Bash(git diff:*)"
+
+      - name: Open a PR if the pass changed anything
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::notice title=Housekeeping::No changes to propose."
+            exit 0
+          fi
+          STAMP="$(date -u +%Y-W%V)"
+          BRANCH="chore/housekeeping-$STAMP"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore: weekly housekeeping ($STAMP)"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: weekly housekeeping ($STAMP)" \
+            --body "Automated housekeeping pass (docs / KB / roadmap / skills / agents). Review the diff before merging." \
+            --base master --head "$BRANCH"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -50,7 +50,7 @@ jobs:
             or open a pull request — a later workflow step owns all git operations. Never edit
             anything under docs/superpowers/specs/ or docs/superpowers/plans/ (immutable history).
           claude_args: |
-            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(grep:*),Bash(ls:*),Bash(comm:*),Bash(git status:*),Bash(git diff:*)"
+            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(grep:*),Bash(ls:*),Bash(comm:*),Bash(sort:*),Bash(wc:*),Bash(sed:*),Bash(xargs:*),Bash(basename:*),Bash(git status:*),Bash(git diff:*)"
 
       - name: Open a PR if the pass changed anything
         if: steps.gate.outputs.proceed == 'true'
@@ -67,7 +67,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add -A
-          git commit -m "chore: weekly housekeeping ($STAMP)"
+          git commit -m "chore: weekly housekeeping ($STAMP)" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
           git push -u origin "$BRANCH"
           gh pr create \
             --title "chore: weekly housekeeping ($STAMP)" \

--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -3,6 +3,13 @@ name: Live Eval
 on:
   push:
     branches: [ "master" ]
+    # Docs / KB / skills / agents don't change server behavior — skip the metered
+    # eval for those merges (e.g. the weekly housekeeping PR). Code, build files,
+    # the eval harness, and workflow changes still trigger a full run on both transports.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.claude/**'
   workflow_dispatch:
 
 # Least-privilege; this workflow only reads the repo and writes its own artifacts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ start with [README.md](README.md); the authoritative design reference is
 
 A Gradle monorepo built on Spring Boot 4.1 / Spring AI 2.0 (Java 21): shared libraries plus one
 **MCP server** per Riot game, currently `lol-mcp-server`, exposing the Riot Games API to AI models
-as six MCP tools across five tool classes. It is a portfolio piece — the value is the clean
+as 13 MCP tools across 11 tool classes. It is a portfolio piece — the value is the clean
 bounded-context hexagonal architecture and the disciplined tests, not feature breadth.
 
 ## Knowledge base — hydrate / persist protocol
@@ -99,10 +99,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the step-by-step recipes and
 - Type: SYNC. Transports: `stdio` (default) and `sse` (message endpoint `/mcp/messages`, port
   `8080`).
 - Tools are auto-discovered via Spring AI's `@McpTool` annotation scanning.
-- `lol-mcp-server` has five tool classes under `com.muddl.riot.lol`, one per context:
+- `lol-mcp-server` has 11 tool classes under `com.muddl.riot.lol`, one per context:
   `RiotAccountTool` (`account.adapter.in.mcp`), `SummonerTool` (`summoner.adapter.in.mcp`),
-  `LiveGameTool` (`spectator.adapter.in.mcp`), `AnalyticsTool` (`analytics.adapter.in.mcp`), and
-  `LeagueTool` (`league.adapter.in.mcp`) — Plan C renamed the tool surface to the
+  `LiveGameTool` (`spectator.adapter.in.mcp`), `AnalyticsTool` (`analytics.adapter.in.mcp`),
+  `LeagueTool` (`league.adapter.in.mcp`), `ChampionTool` (`champion.adapter.in.mcp`),
+  `StatusTool` (`status.adapter.in.mcp`), `ChampionMasteryTool` (`championmastery.adapter.in.mcp`),
+  `ChallengesTool` (`challenges.adapter.in.mcp`), `ClashTool` (`clash.adapter.in.mcp`), and
+  `MatchTool` (`match.adapter.in.mcp`) — Plan C renamed the tool surface to the
   `<game>_<context>_<action>` convention (see [ADR-0009](docs/knowledge/decisions/ADR-0009-mcp-tool-contract.md));
-  it is now **six** tools after `lol_spectator_featured_games` was removed
-  (see [ADR-0013](docs/knowledge/decisions/ADR-0013-remove-featured-games.md)).
+  it is now **13** tools after sub-project 1b added the five breadth contexts plus match tools and
+  `lol_spectator_featured_games` was removed (see
+  [ADR-0013](docs/knowledge/decisions/ADR-0013-remove-featured-games.md) and
+  [ADR-0014](docs/knowledge/decisions/ADR-0014-non-player-keyed-tools.md)).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ enforced at build time (some by ArchUnit, some by Gradle's module graph itself).
 |---|---|---|
 | [`riot-api-core`](riot-api-core/README.md) | Shared Riot HTTP kernel — `RiotApiClient`, routing enums, `RiotApiException`, config | [README](riot-api-core/README.md) · [ARCHITECTURE](riot-api-core/ARCHITECTURE.md) |
 | [`riot-account-core`](riot-account-core/README.md) | Cross-game account context + the player-identity resolver | [README](riot-account-core/README.md) · [ARCHITECTURE](riot-account-core/ARCHITECTURE.md) |
-| [`lol-mcp-server`](lol-mcp-server/README.md) | The League of Legends MCP server (six tools; stdio + sse) | [README](lol-mcp-server/README.md) · [ARCHITECTURE](lol-mcp-server/ARCHITECTURE.md) |
+| [`lol-mcp-server`](lol-mcp-server/README.md) | The League of Legends MCP server (13 tools; stdio + sse) | [README](lol-mcp-server/README.md) · [ARCHITECTURE](lol-mcp-server/ARCHITECTURE.md) |
 
 **Dependency rule:** `lol-mcp-server` → `riot-account-core` → `riot-api-core`, never back — enforced
 by Gradle at compile time (a library simply has no dependency on a game module). Each Riot context

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -34,6 +34,7 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [ADR-0012 — Live agent-driven eval harness (mcp-eval)](decisions/ADR-0012-live-eval-harness.md)
 - [ADR-0013 — Remove the featured-games tool (endpoint retired by Riot)](decisions/ADR-0013-remove-featured-games.md)
 - [ADR-0014 — Non-player-keyed tools extend the tool contract](decisions/ADR-0014-non-player-keyed-tools.md)
+- [ADR-0015 — Repository maintenance automation](decisions/ADR-0015-repo-maintenance-automation.md)
 
 ### Patterns
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -33,6 +33,7 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [ADR-0011 — Documentation topology and the per-module doc gate](decisions/ADR-0011-doc-topology.md)
 - [ADR-0012 — Live agent-driven eval harness (mcp-eval)](decisions/ADR-0012-live-eval-harness.md)
 - [ADR-0013 — Remove the featured-games tool (endpoint retired by Riot)](decisions/ADR-0013-remove-featured-games.md)
+- [ADR-0014 — Non-player-keyed tools extend the tool contract](decisions/ADR-0014-non-player-keyed-tools.md)
 
 ### Patterns
 

--- a/docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md
+++ b/docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md
@@ -1,0 +1,36 @@
+# ADR-0015 — Repository maintenance automation
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+
+## Context
+
+Docs, KB, roadmap, skills, and agents drifted between feature cycles with no reusable procedure to
+catch it (e.g. `CLAUDE.md` said "six tools" long after the surface reached 13; ADR-0014 was missing
+from the KB index). Separately, the PR reviewer (`claude-code-review.yml`) ran green on every PR but
+posted nothing: it used a plugin slash-command prompt with no comment tools and `pull-requests:
+read`, so Claude buffered no comments and could not post — ~$0.16 of subscription usage per PR for
+zero output.
+
+## Decision
+
+- A project skill, `/housekeeping`, is the single reusable definition for the maintenance pass
+  (doc↔code drift, KB integrity, roadmap freshness, skill/agent fitness, changelog↔versions), with
+  `docs/superpowers/specs|plans` treated as immutable history.
+- A weekly, commit-gated `housekeeping.yml` runs that skill on the flat-rate `CLAUDE_CODE_OAUTH_TOKEN`
+  seat and opens a PR — never merging unreviewed.
+- The PR reviewer and `@claude` workflows are moved to the action's canonical posting form with
+  `pull-requests: write` (and `issues: write` for `@claude`).
+- Metered cost is scoped to `live-eval` (the only `ANTHROPIC_API_KEY` consumer): a `paths-ignore`
+  filter skips no-op doc/skill merges; the full eval on both transports is retained. Prompt caching
+  was evaluated and rejected for this workload (short independent Haiku conversations under the
+  4096-token cacheable minimum).
+
+## Consequences
+
+- Maintenance is repeatable and partly automated; the weekly PR keeps drift bounded.
+- The reviewer now produces real, reviewable feedback; verification requires observing a live PR, not
+  a green run.
+- The two credential buckets stay separated (ADR-0012): interactive/housekeeping on the flat seat,
+  eval on the metered key. Moving any interactive Action onto the metered key is explicitly out of
+  scope.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -203,3 +203,11 @@ WireMock test passed only because its fixture had encoded the documented shape. 
 it. **Lesson:** confirm field names against a real response (`curl` with a key), not just the portal
 schema; when both shapes exist, accept them with `@JsonAlias`. This is the concrete case behind the
 standing "verify against the live developer portal, never assume" constraint.
+
+## PRs opened by `GITHUB_TOKEN` do not trigger other workflows
+
+GitHub deliberately does not fire `pull_request`/`push` workflow events for refs created or PRs
+opened using the automatic `GITHUB_TOKEN` (to prevent recursive runs). So the weekly
+`housekeeping.yml` PR (opened via `gh pr create` with `GITHUB_TOKEN`) will NOT get an automatic
+`claude-code-review.yml` run. That is expected, not a bug. If auto-review on those PRs is ever
+wanted, open them with a PAT or GitHub App token instead of `GITHUB_TOKEN`.

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -116,7 +116,7 @@ Real and wanted, deliberately not scheduled. Recorded so they are not re-derived
 | Generalized host-routing abstraction | Forced by sub-project 3. TFT reuses LoL's hosts, so one data point is not enough to design from. |
 | Publishing libraries as Maven artifacts | Not planned. Libraries are versioned for provenance and consumed by project reference — see ADR-0010. |
 | Aggregate coverage report | When more than one server exists. |
-| **Claude Code Actions integration rework** | Own effort. The repo's `claude.yml` / `claude-code-action` wiring is to be reworked for better automation writ large. Recorded as intended, not yet scheduled. Kept in a separate credential bucket (`CLAUDE_CODE_OAUTH_TOKEN`) from the live-eval harness's `ANTHROPIC_API_KEY`. |
+| ~~Claude Code Actions integration rework~~ | **Shipped** ([ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md)). The PR reviewer now posts real reviews, `@claude` can respond, and a weekly `/housekeeping` cron opens maintenance PRs — all on `CLAUDE_CODE_OAUTH_TOKEN`, separate from live-eval's `ANTHROPIC_API_KEY`. |
 | ~~Automated endpoint-path verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). Live agent-driven evals call every tool against the real Riot API post-merge; a wrong path returns 404 and fails the eval, so paths are verified continuously rather than by a human opening the portal. |
 | ~~Automated transport-handshake verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). The suite runs over both stdio and sse each post-merge run; a successful stdio session is the stdout-purity check. |
 

--- a/docs/superpowers/plans/2026-07-19-repo-housekeeping-and-actions.md
+++ b/docs/superpowers/plans/2026-07-19-repo-housekeeping-and-actions.md
@@ -1,0 +1,649 @@
+# Repository Housekeeping + Claude Code Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a reusable `/housekeeping` skill and a weekly PR-opening cron that runs it, fix the no-op PR reviewer so it posts real reviews, and cut metered `live-eval` runs on no-op merges.
+
+**Architecture:** A project skill (`.claude/skills/housekeeping/`) carries the audit checklist as durable context; a scheduled, commit-gated GitHub workflow runs it on the flat-rate OAuth seat and opens a PR. The PR reviewer is rebuilt from the plugin-slash-command form (which emitted nothing) to the action's canonical automated-review form (direct prompt + `--allowedTools` for the comment tools) with `pull-requests: write`. `live-eval` gains a `paths-ignore` filter so docs/skill-only merges don't spend metered tokens.
+
+**Tech Stack:** GitHub Actions, `anthropics/claude-code-action@v1`, Claude Code skills (Markdown), `gh` CLI, Bash. No application (Java) code changes.
+
+## Global Constraints
+
+- **Two credential buckets, kept separate** (ADR-0012): interactive + housekeeping Actions authenticate with `CLAUDE_CODE_OAUTH_TOKEN` (flat-rate seat); `live-eval` is the only consumer of `ANTHROPIC_API_KEY` (metered). Never move an interactive/housekeeping Action onto the metered key.
+- **Actual tool count is 13** (unique `name = "…"` values under `lol-mcp-server/src/main`); never hardcode a count without re-deriving it from source.
+- **Dated specs/plans are immutable history** — `docs/superpowers/specs/` and `docs/superpowers/plans/` are never edited or trimmed by housekeeping.
+- **Offline suite stays key-free** — nothing here adds a test that needs a live key or network.
+- **A green Actions run is not proof of success** — the PR reviewer fix is only "done" once a real review is observed on a test PR.
+- Commit messages end with the repo's trailer:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` and the `Claude-Session:` line.
+- All work lands on branch `chore/housekeeping-and-actions` (already created; the design spec is its first commit).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `.claude/skills/housekeeping/SKILL.md` | **New.** The reusable audit checklist + procedure (2 modes). |
+| `.github/workflows/housekeeping.yml` | **New.** Weekly, commit-gated run that edits, then branches + opens a PR. |
+| `.github/workflows/claude-code-review.yml` | **Rewrite.** Canonical automated review that actually posts. |
+| `.github/workflows/claude.yml` | **Modify.** Add `pull-requests: write` + `issues: write`. |
+| `.github/workflows/live-eval.yml` | **Modify.** Add `paths-ignore` to the `push` trigger. |
+| `CLAUDE.md` | **Modify (dogfood).** Fix stale tool count. |
+| `docs/knowledge/README.md` | **Modify (dogfood + persist).** Add ADR-0014, and the new ADR, to the list. |
+| `docs/knowledge/roadmap.md` | **Modify (persist).** Close the "Claude Code Actions integration rework" row. |
+| `docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md` | **New (persist).** Record this decision. |
+
+---
+
+### Task 1: Author the `/housekeeping` skill
+
+**Files:**
+- Create: `.claude/skills/housekeeping/SKILL.md`
+
+**Interfaces:**
+- Produces: an invocable skill named `housekeeping`, accepting an optional `--audit-only` argument. Consumed by a human (`/housekeeping`) and by `housekeeping.yml` (Task 5).
+
+- [ ] **Step 1: Write the skill file**
+
+Create `.claude/skills/housekeeping/SKILL.md` with exactly this content:
+
+```markdown
+---
+name: housekeeping
+description: Audit and trim the repo's docs, knowledge base, roadmap, skills, and agents so they stay accurate and fit-for-purpose. Use for a periodic maintenance pass, or when doc drift is suspected. Accepts `--audit-only` to report without editing.
+---
+
+# Repository housekeeping
+
+Keep `riot-api-mcp-server`'s durable context — docs, knowledge base, roadmap, skills, agents —
+accurate, trim, and consistent with the real project. This is the reusable definition behind both
+the manual `/housekeeping` pass and the weekly `housekeeping.yml` Action.
+
+## Modes
+
+- **`--audit-only`** — report findings as a checklist; make no edits.
+- **default** — apply the fixes, keeping each change small and single-purpose.
+
+## Hydrate first
+
+Read `docs/knowledge/README.md` (the hydrate/persist protocol), then `roadmap.md` and `gotchas.md`,
+so fixes stay consistent with recorded decisions. For any non-trivial doc rewrite, delegate the
+prose to the `docs-maintainer` agent rather than restating its rules here.
+
+## Audit checklist
+
+Work through each item. For every finding, note the file, the drift, and the fix.
+
+1. **Doc ↔ code drift.** Re-derive facts from source and reconcile prose in `README.md`,
+   `ARCHITECTURE.md`, `CLAUDE.md`, `CONTRIBUTING.md`:
+   - Tool count = unique `name = "…"` values:
+     `grep -rhoE 'name = "[a-z_]+"' --include=*.java lol-mcp-server/src/main | sort -u | wc -l`
+   - Tool classes = files declaring `@McpTool` under `adapter/in/mcp`:
+     `grep -rl "@McpTool" --include=*.java lol-mcp-server/src/main | grep 'adapter/in/mcp' | wc -l`
+   - Context/package names and transport details (`stdio`/`sse`) match the source tree.
+2. **KB integrity.**
+   - Every ADR on disk is linked from `docs/knowledge/README.md`:
+     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)`
+   - ADR numbering is contiguous; superseded ADRs carry `Superseded by ADR-00NN`.
+   - Every relative Markdown link resolves (no dead targets) across `docs/knowledge/` and root docs.
+3. **Roadmap freshness.** `roadmap.md` status table matches reality; dates are absolute (not "last
+   week"); deferred items are still true.
+4. **Skills & agents fit-for-purpose.** Each `.claude/skills/*/SKILL.md` and `.claude/agents/*.md`
+   references real files, commands, and tool names; descriptions are accurate; nothing is stale or
+   duplicated.
+5. **CHANGELOG ↔ versions.** Module versions and `CHANGELOG.md` entries are consistent.
+
+## Hands-off (never touch)
+
+`docs/superpowers/specs/` and `docs/superpowers/plans/` are dated snapshots — immutable history.
+Do not edit or trim them. Scope moves in `roadmap.md`, not in the dated specs.
+
+## Finishing
+
+- **`--audit-only`:** print the findings checklist and stop.
+- **default:** apply fixes, then persist per `docs/knowledge/README.md` — a new pitfall goes to
+  `gotchas.md`, a new decision becomes an ADR (and is linked from the KB README). Do not commit or
+  open a PR yourself; the caller (human or workflow) owns git.
+```
+
+- [ ] **Step 2: Verify the skill is discovered and audits cleanly**
+
+Run: `/housekeeping --audit-only`
+Expected: the session loads the skill and prints a findings checklist that includes at least the
+known-stale items — `CLAUDE.md` tool count says "six" (should be 13) and `docs/knowledge/README.md`
+omits ADR-0014. No files are edited.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/housekeeping/SKILL.md
+git commit -m "feat(skill): add /housekeeping audit definition
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 2: Dogfood the skill — fix current drift
+
+**Files:**
+- Modify: `CLAUDE.md` (lines ~11 and ~107 — the two "six" references)
+- Modify: `docs/knowledge/README.md` (ADR list — add ADR-0014)
+
+**Interfaces:**
+- Consumes: the `housekeeping` skill from Task 1.
+- Produces: a clean audit (a second `--audit-only` run reports no doc↔code or KB-integrity findings).
+
+- [ ] **Step 1: Re-derive the true tool count and classes**
+
+Run:
+```bash
+grep -rhoE 'name = "[a-z_]+"' --include=*.java lol-mcp-server/src/main | sort -u | wc -l
+grep -rl "@McpTool" --include=*.java lol-mcp-server/src/main | grep 'adapter/in/mcp' | wc -l
+```
+Expected: `13` tools. Record the tool-classes number the second command prints — use it verbatim in the next step (do not assume "five").
+
+- [ ] **Step 2: Fix the stale tool count in `CLAUDE.md`**
+
+Line ~11 currently reads:
+```
+as six MCP tools across five tool classes. It is a portfolio piece — the value is the clean
+```
+Replace `six MCP tools across five tool classes` with `13 MCP tools across <N> tool classes`, using the class count from Step 1 for `<N>`.
+
+Line ~107 currently reads:
+```
+  it is now **six** tools after `lol_spectator_featured_games` was removed
+```
+Replace `**six** tools` with `**13** tools`.
+
+- [ ] **Step 3: Add ADR-0014 to the KB README ADR list**
+
+In `docs/knowledge/README.md`, immediately after the `ADR-0013` list item, add:
+```markdown
+- [ADR-0014 — Non-player-keyed tools extend the tool contract](decisions/ADR-0014-non-player-keyed-tools.md)
+```
+
+- [ ] **Step 4: Re-run the audit to confirm the drift is gone**
+
+Run: `/housekeeping --audit-only`
+Expected: no findings for doc↔code tool count or the ADR-0014 KB-integrity gap. (Any remaining findings the pass surfaces should be fixed the same way before committing.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md docs/knowledge/README.md
+git commit -m "docs: housekeeping pass — sync tool count (6->13), link ADR-0014
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 3: Rebuild the PR reviewer so it posts
+
+**Files:**
+- Modify (rewrite): `.github/workflows/claude-code-review.yml`
+
+**Interfaces:**
+- Consumes: `secrets.CLAUDE_CODE_OAUTH_TOKEN` (unchanged bucket).
+- Produces: a reviewer that posts a top-level summary + inline comments on every non-draft PR.
+
+Root cause being fixed: the old config passed `/code-review:code-review <PR>` as the prompt with no comment tools and `pull-requests: read`, so Claude ran ~2 turns, buffered no comments, and could not post. The action's canonical automated-review form instructs Claude to post via `gh pr comment` / `mcp__github_inline_comment__create_inline_comment` and grants those tools.
+
+- [ ] **Step 1: Replace the workflow with the canonical review form**
+
+Overwrite `.github/workflows/claude-code-review.yml` with exactly:
+
+```yaml
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # REQUIRED to post reviews/comments (was `read` — the no-op cause)
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for a Spring Boot 4 / Spring AI MCP server (Java 21,
+            bounded-context hexagonal architecture). Focus on:
+            - Correctness and potential bugs, especially null-safety in Riot DTOs and error mapping.
+            - Hexagonal boundary violations: adapter -> application -> domain (inward only);
+              @McpTool only in adapter.in.mcp; RestClient only in adapter.out.riot.
+            - Test coverage: WireMock for outbound adapters, in-memory port fakes for services.
+            - Security: RIOT_API_KEY must never be logged or hard-coded.
+
+            The PR branch is already checked out in the working directory.
+
+            Use `gh pr comment` for top-level summary feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for
+            specific line-level issues.
+            Only post GitHub comments — do not submit review text as chat messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/claude-code-review.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/claude-code-review.yml
+git commit -m "fix(ci): make PR reviewer actually post reviews
+
+Replace the no-op plugin-slash-command prompt (buffered no comments, ran ~2
+turns) with the canonical automated-review form: a direct review prompt that
+posts via gh pr comment / inline-comment tools, granted via --allowedTools,
+with pull-requests: write. Skip drafts.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+- [ ] **Step 4: Live verification (do at PR time — see Task 8)**
+
+The reviewer can only be proven against a real PR. Task 8's PR is that verification: confirm a Claude review (summary comment + any inline comments) appears on it. If none appears, inspect the run log for the `post-buffered-inline-comments` step and the token `PullRequests:` permission before considering this task done.
+
+---
+
+### Task 4: Let `@claude` post on PRs and issues
+
+**Files:**
+- Modify: `.github/workflows/claude.yml` (the `permissions:` block, ~lines 21-26)
+
+**Interfaces:**
+- Produces: `@claude` mentions can leave comments (previously read-only, so silent).
+
+- [ ] **Step 1: Grant write scopes**
+
+In `.github/workflows/claude.yml`, change the `permissions:` block from:
+```yaml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+```
+to:
+```yaml
+    permissions:
+      contents: read
+      pull-requests: write   # post review comments when @claude-mentioned on a PR
+      issues: write          # respond on issues when @claude-mentioned
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/claude.yml
+git commit -m "fix(ci): grant @claude workflow write scopes so it can respond
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 5: Weekly housekeeping workflow → PR
+
+**Files:**
+- Create: `.github/workflows/housekeeping.yml`
+
+**Interfaces:**
+- Consumes: the `housekeeping` skill (Task 1); `secrets.CLAUDE_CODE_OAUTH_TOKEN`.
+- Produces: a weekly, commit-gated run that edits the working tree, then branches, commits, and opens a PR titled `chore: weekly housekeeping (<year>-W<week>)`.
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/housekeeping.yml` with exactly:
+
+```yaml
+name: Weekly Housekeeping
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:        # manual runs always proceed (bypass the commit gate)
+
+# Least-privilege; elevate only where needed.
+permissions:
+  contents: read
+
+jobs:
+  housekeeping:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create the housekeeping branch
+      pull-requests: write   # open the PR
+      id-token: write
+    steps:
+      - name: Checkout (full history for the commit gate)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Gate: on a scheduled run, proceed only if commits landed in the last week.
+      # Manual (workflow_dispatch) runs always proceed.
+      - name: Commit gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          COUNT="$(git rev-list --count --since='1 week ago' HEAD)"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Housekeeping::$COUNT commit(s) in the last week — running."
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Housekeeping skipped::No commits in the last week."
+          fi
+
+      - name: Run housekeeping skill (apply mode, edits only)
+        if: steps.gate.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Run the housekeeping skill to audit and fix drift in this repo's docs, knowledge base,
+            roadmap, skills, and agents. Apply the fixes to the working tree. Do NOT commit, push,
+            or open a pull request — a later workflow step owns all git operations. Never edit
+            anything under docs/superpowers/specs/ or docs/superpowers/plans/ (immutable history).
+          claude_args: |
+            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(grep:*),Bash(ls:*),Bash(comm:*),Bash(git status:*),Bash(git diff:*)"
+
+      - name: Open a PR if the pass changed anything
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::notice title=Housekeeping::No changes to propose."
+            exit 0
+          fi
+          STAMP="$(date -u +%Y-W%V)"
+          BRANCH="chore/housekeeping-$STAMP"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore: weekly housekeeping ($STAMP)"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: weekly housekeeping ($STAMP)" \
+            --body "Automated housekeeping pass (docs / KB / roadmap / skills / agents). Review the diff before merging." \
+            --base master --head "$BRANCH"
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/housekeeping.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Static-check the gate logic locally**
+
+Run (simulates the scheduled gate against real history):
+```bash
+git rev-list --count --since='1 week ago' HEAD
+```
+Expected: a non-negative integer. A value `> 0` means a scheduled run would proceed; `0` means it would skip. (This validates the gate command runs; the workflow itself is exercised in Task 8 via `workflow_dispatch`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/housekeeping.yml
+git commit -m "feat(ci): add weekly housekeeping workflow that opens a PR
+
+Commit-gated (skips quiet weeks; manual dispatch always runs), runs the
+/housekeeping skill on the flat-rate OAuth seat, then branches + opens a PR.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 6: Path-filter `live-eval` to skip no-op merges
+
+**Files:**
+- Modify: `.github/workflows/live-eval.yml` (the `on: push:` block, ~lines 3-6)
+
+**Interfaces:**
+- Produces: metered live-eval no longer runs on merges that touch only docs / KB / skills (no server-behavior change). Full eval on both transports is unchanged for server/eval/workflow changes.
+
+- [ ] **Step 1: Add `paths-ignore` to the push trigger**
+
+In `.github/workflows/live-eval.yml`, change:
+```yaml
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+```
+to:
+```yaml
+on:
+  push:
+    branches: [ "master" ]
+    # Docs / KB / skills / agents don't change server behavior — skip the metered
+    # eval for those merges (e.g. the weekly housekeeping PR). Code, build files,
+    # the eval harness, and workflow changes still trigger a full run on both transports.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.claude/**'
+  workflow_dispatch:
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/live-eval.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/live-eval.yml
+git commit -m "ci(cost): skip metered live-eval on docs/KB/skill-only merges
+
+paths-ignore for markdown, docs/, and .claude/ so the weekly housekeeping PR
+and other doc-only merges don't spend a full metered eval. Full eval on both
+transports still runs for server, build, eval-harness, and workflow changes.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 7: Persist the decision (ADR + roadmap)
+
+**Files:**
+- Create: `docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md`
+- Modify: `docs/knowledge/README.md` (ADR list — add ADR-0015)
+- Modify: `docs/knowledge/roadmap.md` (close the "Claude Code Actions integration rework" row)
+
+**Interfaces:**
+- Consumes: the KB README ADR list already patched for ADR-0014 in Task 2.
+- Produces: a linked ADR-0015 and an updated roadmap.
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md`:
+
+```markdown
+# ADR-0015 — Repository maintenance automation
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+
+## Context
+
+Docs, KB, roadmap, skills, and agents drifted between feature cycles with no reusable procedure to
+catch it (e.g. `CLAUDE.md` said "six tools" long after the surface reached 13; ADR-0014 was missing
+from the KB index). Separately, the PR reviewer (`claude-code-review.yml`) ran green on every PR but
+posted nothing: it used a plugin slash-command prompt with no comment tools and `pull-requests:
+read`, so Claude buffered no comments and could not post — ~$0.16 of subscription usage per PR for
+zero output.
+
+## Decision
+
+- A project skill, `/housekeeping`, is the single reusable definition for the maintenance pass
+  (doc↔code drift, KB integrity, roadmap freshness, skill/agent fitness, changelog↔versions), with
+  `docs/superpowers/specs|plans` treated as immutable history.
+- A weekly, commit-gated `housekeeping.yml` runs that skill on the flat-rate `CLAUDE_CODE_OAUTH_TOKEN`
+  seat and opens a PR — never merging unreviewed.
+- The PR reviewer and `@claude` workflows are moved to the action's canonical posting form with
+  `pull-requests: write` (and `issues: write` for `@claude`).
+- Metered cost is scoped to `live-eval` (the only `ANTHROPIC_API_KEY` consumer): a `paths-ignore`
+  filter skips no-op doc/skill merges; the full eval on both transports is retained. Prompt caching
+  was evaluated and rejected for this workload (short independent Haiku conversations under the
+  4096-token cacheable minimum).
+
+## Consequences
+
+- Maintenance is repeatable and partly automated; the weekly PR keeps drift bounded.
+- The reviewer now produces real, reviewable feedback; verification requires observing a live PR, not
+  a green run.
+- The two credential buckets stay separated (ADR-0012): interactive/housekeeping on the flat seat,
+  eval on the metered key. Moving any interactive Action onto the metered key is explicitly out of
+  scope.
+```
+
+- [ ] **Step 2: Link ADR-0015 from the KB README**
+
+In `docs/knowledge/README.md`, immediately after the `ADR-0014` list item (added in Task 2), add:
+```markdown
+- [ADR-0015 — Repository maintenance automation](decisions/ADR-0015-repo-maintenance-automation.md)
+```
+
+- [ ] **Step 3: Close the roadmap's deferred row**
+
+In `docs/knowledge/roadmap.md`, in the "Deferred, with a home" table, replace the row:
+```markdown
+| **Claude Code Actions integration rework** | Own effort. The repo's `claude.yml` / `claude-code-action` wiring is to be reworked for better automation writ large. Recorded as intended, not yet scheduled. Kept in a separate credential bucket (`CLAUDE_CODE_OAUTH_TOKEN`) from the live-eval harness's `ANTHROPIC_API_KEY`. |
+```
+with:
+```markdown
+| ~~Claude Code Actions integration rework~~ | **Shipped** ([ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md)). The PR reviewer now posts real reviews, `@claude` can respond, and a weekly `/housekeeping` cron opens maintenance PRs — all on `CLAUDE_CODE_OAUTH_TOKEN`, separate from live-eval's `ANTHROPIC_API_KEY`. |
+```
+
+- [ ] **Step 4: Verify links resolve**
+
+Run:
+```bash
+comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)
+```
+Expected: empty output (every ADR file is linked from the README).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md docs/knowledge/README.md docs/knowledge/roadmap.md
+git commit -m "docs(kb): ADR-0015 maintenance automation; close roadmap Actions row
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JuKKZJAwVZdj8gvxd2ujgt"
+```
+
+---
+
+### Task 8: Open the PR and verify Actions live
+
+**Files:** none (integration/verification task)
+
+**Interfaces:**
+- Consumes: all prior tasks, on branch `chore/housekeeping-and-actions`.
+- Produces: a merged-ready PR whose own CI run proves the reviewer posts and the eval filter behaves.
+
+- [ ] **Step 1: Confirm the offline gate still passes**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL` (no Java changed, but confirm nothing regressed).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin chore/housekeeping-and-actions
+gh pr create --base master --head chore/housekeeping-and-actions \
+  --title "chore: housekeeping skill + Claude Code Actions fix" \
+  --body "Implements docs/superpowers/specs/2026-07-19-repo-housekeeping-and-actions-design.md — /housekeeping skill, weekly PR-opening cron, PR-reviewer fix (now posts), and a live-eval path filter."
+```
+
+- [ ] **Step 3: Verify the reviewer posts on this very PR**
+
+Wait for the `Claude Code Review` run on the PR to finish, then:
+```bash
+gh pr view --json comments,reviews -q '{comments: (.comments|length), reviews: (.reviews|length)}'
+```
+Expected: a non-zero comment/review count, i.e. Claude left an actual review. If zero, open the run log and check the token `PullRequests:` line (must be `write`) and the `post-buffered-inline-comments` / tool-call output before declaring done. This is the falsifiable proof the no-op is fixed.
+
+- [ ] **Step 4: Verify the eval filter behaved**
+
+This PR touches `.github/**` (not in `paths-ignore`), so on merge `Live Eval` **should** run. Confirm after merge:
+```bash
+gh run list --workflow=live-eval.yml --limit 1
+```
+Expected: a run triggered by the merge. (A later docs-only housekeeping PR is what will be *skipped* — that is validated organically by the weekly cron.)
+
+- [ ] **Step 5: Optionally smoke-test the housekeeping cron now**
+
+```bash
+gh workflow run housekeeping.yml
+gh run list --workflow=housekeeping.yml --limit 1
+```
+Expected: a manual run (bypasses the commit gate) that either opens a `chore/housekeeping-<stamp>` PR or logs "No changes to propose" if the repo is already clean from Task 2.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Reusable `/housekeeping` skill (spec §1) → Task 1. ✅
+- Weekly commit-gated PR-opening Action (spec §2) → Task 5. ✅
+- PR reviewer fix: write perms + real posting config + live verification (spec §3) → Tasks 3, 8. ✅
+- `@claude` write scopes (spec §3 table) → Task 4. ✅
+- Metered-cost path filter, full×both retained, caching rejected with rationale (spec §4) → Task 6, ADR-0015 (Task 7). ✅
+- Dogfood to fix current drift (spec §5) → Task 2. ✅
+- Persist: ADR + close roadmap row (spec "Net change set") → Task 7. ✅
+- Two-bucket constraint honored — all interactive/housekeeping Actions stay on `CLAUDE_CODE_OAUTH_TOKEN`. ✅
+
+**Placeholder scan:** No TBD/TODO. The one deferred identifier at spec time (ADR number) is now concrete: **ADR-0015**. Tool count is concrete (**13**); tool-class count is derived in Task 2 Step 1 with an exact command rather than guessed.
+
+**Type/name consistency:** Skill name `housekeeping` and its `--audit-only` arg are used identically in Tasks 1, 2, 5. Workflow filenames, the `chore/housekeeping-<stamp>` branch pattern, and `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` bucket usage are consistent across tasks. The `--allowedTools` tool names in Task 3 match the action's canonical review example verbatim.
+```

--- a/docs/superpowers/plans/2026-07-19-repo-housekeeping-and-actions.md
+++ b/docs/superpowers/plans/2026-07-19-repo-housekeeping-and-actions.md
@@ -85,7 +85,7 @@ Work through each item. For every finding, note the file, the drift, and the fix
    - Context/package names and transport details (`stdio`/`sse`) match the source tree.
 2. **KB integrity.**
    - Every ADR on disk is linked from `docs/knowledge/README.md`:
-     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)`
+     `comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'decisions/ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sed 's|decisions/||' | sort -u)`
    - ADR numbering is contiguous; superseded ADRs carry `Superseded by ADR-00NN`.
    - Every relative Markdown link resolves (no dead targets) across `docs/knowledge/` and root docs.
 3. **Roadmap freshness.** `roadmap.md` status table matches reality; dates are absolute (not "last
@@ -567,7 +567,7 @@ with:
 
 Run:
 ```bash
-comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sort -u)
+comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'decisions/ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sed 's|decisions/||' | sort -u)
 ```
 Expected: empty output (every ADR file is linked from the README).
 

--- a/docs/superpowers/specs/2026-07-19-repo-housekeeping-and-actions-design.md
+++ b/docs/superpowers/specs/2026-07-19-repo-housekeeping-and-actions-design.md
@@ -1,0 +1,155 @@
+# Repository housekeeping + Claude Code Actions — design
+
+- **Date:** 2026-07-19
+- **Status:** Approved (brainstorming), pending implementation plan
+- **Scope:** A reusable "housekeeping" definition for keeping docs/KB/roadmap/skills/agents trim
+  and current; a weekly automated run of it; a real fix for the no-op PR reviewer; and a metered-cost
+  audit of everything that touches `ANTHROPIC_API_KEY`.
+
+## Problem
+
+Two recurring maintenance needs have no home:
+
+1. **Docs, roadmap, knowledge base, skills, and agents drift.** They are maintained ad hoc, so
+   staleness accumulates between feature cycles. Confirmed live examples at authoring time:
+   - `CLAUDE.md` still says the LoL server exposes **six** tools; the roadmap records the surface
+     grew to **13** in sub-project 1b.
+   - `docs/knowledge/README.md`'s ADR list stops at **ADR-0013**, but **ADR-0014** exists on disk.
+
+   There is no reusable, context-carrying procedure for catching this, so each pass re-derives what to
+   check.
+
+2. **Claude Code Actions is not doing useful work.** The PR reviewer (`claude-code-review.yml`) runs
+   green on every PR but **never posts a review or comment** — verified against run `29673932693`
+   (PR #55): Claude's own execution summary is `"num_turns": 2, "total_cost_usd": 0.157`, the action's
+   posting step logs `No buffered inline comments`, and the workflow token grants only
+   `PullRequests: read`. It spins, costs ~$0.16 of subscription usage per PR, and produces nothing.
+
+Separately, a **cost audit** of `ANTHROPIC_API_KEY` usage is wanted, "especially for repetitive tasks
+like the live eval reg tests and the newly created PR reviewers and scheduled cleanup."
+
+## Key reframing: two credential buckets
+
+Cost optimization hinges on a distinction the current wiring already encodes (see
+[ADR-0012](../../knowledge/decisions/ADR-0012-live-eval-harness.md)):
+
+| Credential | Billing | Consumed by |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | **Metered** (pay-per-token) | `live-eval.yml` **only** |
+| `CLAUDE_CODE_OAUTH_TOKEN` | **Flat** (Claude subscription seat) | `claude.yml`, `claude-code-review.yml`, and the new `housekeeping.yml` |
+
+Consequence: the PR reviewer and the scheduled cleanup do **not** spend metered tokens as long as they
+stay on the OAuth token — so "optimize their `ANTHROPIC_API_KEY` cost" is a non-goal. Their lever is
+**invocation frequency** (conserves subscription rate-limit, not dollars). Only `live-eval` spends
+metered tokens, and that is where the cost audit actually bites.
+
+## Design
+
+### 1. The `/housekeeping` skill — the reusable definition
+
+A project skill at `.claude/skills/housekeeping/SKILL.md`, invoked by both a human (`/housekeeping`)
+and the weekly Action headlessly. It carries the audit checklist as durable context so it survives
+across sessions. Two modes:
+
+- `--audit-only` — report findings, make no edits.
+- default — apply the trimming/drift fixes.
+
+**Checklist (what a pass verifies):**
+
+- **Doc ↔ code drift** — tool counts, context/package names, and transport details in `README.md`,
+  `ARCHITECTURE.md`, `CLAUDE.md`, and `CONTRIBUTING.md` against the actual source (e.g. the "six
+  tools" staleness).
+- **KB integrity** — every ADR on disk is listed in `docs/knowledge/README.md` (ADR-0014 is currently
+  missing), ADR numbering is contiguous, superseded ADRs are marked `Superseded by …`, and every
+  relative markdown link resolves.
+- **Roadmap freshness** — the status table matches reality, dates are absolute, and deferred items are
+  still true (e.g. the "Claude Code Actions integration rework" row, which this effort closes).
+- **Skills & agents fit-for-purpose** — the skills and agents still reference real files, commands,
+  and tool names; descriptions are accurate; nothing is stale.
+- **CHANGELOG ↔ versions** — consistency between module versions and changelog entries.
+
+**Explicitly hands-off:** `docs/superpowers/specs/` and `docs/superpowers/plans/` are dated, immutable
+history — the skill never edits or trims them, matching the repo's own rule that specs are snapshots
+of a decision at a moment.
+
+**Reuse, don't duplicate:** the skill leans on the existing `docs-maintainer` agent for the
+doc-writing/persist mechanics rather than restating them.
+
+### 2. Weekly housekeeping Action → PR
+
+New `.github/workflows/housekeeping.yml`:
+
+- **Triggers:** `schedule` (weekly) + `workflow_dispatch`.
+- **Commit gate:** run the skill only if commits landed on `master` since the last housekeeping run;
+  otherwise exit clean. (Keeps quiet weeks free.)
+- **Auth:** `CLAUDE_CODE_OAUTH_TOKEN` (flat-rate; not metered).
+- **Output:** applies fixes on a `chore/housekeeping-YYYY-WW` branch and **opens a PR** for review.
+  Nothing merges without a human.
+- **Permissions:** `contents: write` + `pull-requests: write` (to branch and open the PR).
+
+### 3. Fix the PR reviewer so it reviews and posts
+
+Root cause is twofold (both must be fixed):
+
+1. **No postable output.** `/code-review:code-review <PR>` as the prompt yields a ~2-turn run that
+   emits nothing into the action's inline-comment buffer (`No buffered inline comments`). Replace it
+   with the current supported automated-review configuration for `anthropics/claude-code-action@v1`:
+   a direct review prompt plus `claude_args` granting the review/comment tools, so findings are
+   actually produced and posted inline. **Exact prompt + tool-allow syntax will be pinned against the
+   action's own docs during implementation (WebFetch), not guessed here.**
+2. **Can't post.** Grant `pull-requests: write` on `claude-code-review.yml`, and
+   `pull-requests: write` + `issues: write` on `claude.yml` (`@claude`) so it can respond on PRs and
+   issues.
+
+**Verification is part of "done":** open a throwaway PR after the change and confirm a real review
+lands. A green run is not sufficient evidence — that is exactly the failure mode being fixed.
+
+### 4. Metered-cost changes (all in `live-eval.yml`)
+
+Current baseline is already lean: **Haiku 4.5** ($1/$5 per 1M — cheapest tier) for agent and judge,
+`max_concurrency: 1`, `max_iterations: 4`, `retry_failed: false`. Keep all of that.
+
+- **Keep the full agentic eval on both transports** (stdio + sse) — decision recorded; maximum
+  redundancy retained.
+- **Path-filter the `push` trigger** so docs-only / eval-only / housekeeping merges — which do not
+  change server behavior — do not spend a full metered run. Keep `workflow_dispatch`.
+- **Prompt caching is deliberately not pursued for this workload**, and this is a considered call, not
+  an omission: each eval test is a short, independent ≤4-iteration conversation, the cacheable prefix
+  (system + 13 small tool schemas) very likely falls under Haiku's **4096-token** minimum cacheable
+  prefix (so `cache_control` would silently no-op), and it is unclear the `mcp-eval` harness even
+  exposes cache breakpoints. If revisited, it must be validated empirically
+  (`usage.cache_read_input_tokens > 0`) before any effort is spent.
+- **Optional, not included by default:** a weekly `schedule` on `live-eval` so the canaries still catch
+  Riot-side drift during commit-quiet weeks. Left out unless requested, since it adds runs.
+
+### 5. This session dogfoods the skill
+
+After the plan, implementation runs `/housekeeping` to fix today's real drift (the "six tools"
+staleness, the missing ADR-0014 link, and whatever else the pass surfaces). This both cleans the repo
+now and validates that the skill's checklist is correct.
+
+## Net change set
+
+| Artifact | Change |
+|---|---|
+| `.claude/skills/housekeeping/SKILL.md` | **New** — the reusable audit definition (2 modes). |
+| `.github/workflows/housekeeping.yml` | **New** — weekly, commit-gated, opens a PR; OAuth auth. |
+| `.github/workflows/claude-code-review.yml` | Real review prompt + `claude_args` tools; `pull-requests: write`. |
+| `.github/workflows/claude.yml` | `pull-requests: write` + `issues: write`. |
+| `.github/workflows/live-eval.yml` | Path-filter the `push` trigger (keep full × both transports). |
+| Docs/KB (drift fixes) | Applied by dogfooding `/housekeeping` this cycle. |
+| `docs/knowledge/decisions/ADR-00NN-*.md` | **New** ADR recording the housekeeping-automation decision. |
+| `docs/knowledge/roadmap.md` | Close the "Claude Code Actions integration rework" deferred row. |
+
+## Standing constraints (unchanged)
+
+- The offline test suite remains the pre-merge gate and needs no keys; nothing here introduces
+  key-requiring tests.
+- The two credential buckets stay separate (`CLAUDE_CODE_OAUTH_TOKEN` for the interactive/housekeeping
+  Actions; `ANTHROPIC_API_KEY` for the live eval), per ADR-0012.
+
+## Out of scope
+
+- Moving any interactive Action onto the metered `ANTHROPIC_API_KEY` (they stay on the flat seat).
+- Editing dated specs/plans as part of housekeeping (they are immutable history).
+- Prompt caching in the eval harness (deferred, gated on empirical evidence — see §4).

--- a/lol-mcp-server/README.md
+++ b/lol-mcp-server/README.md
@@ -10,10 +10,12 @@ the player-identity resolver) — and adds the LoL-specific bounded contexts.
 
 ## MCP tools
 
-Five inbound adapters expose **six** tools. Every player-keyed tool takes a single `player`
+Eleven inbound adapters expose **13** tools. Every player-keyed tool takes a single `player`
 parameter accepting either a Riot ID (`GameName#TAG`) or a raw PUUID, resolved internally — the model
 never has to chain `account → summoner → match` itself (see
-[ADR-0009](../docs/knowledge/decisions/ADR-0009-mcp-tool-contract.md)).
+[ADR-0009](../docs/knowledge/decisions/ADR-0009-mcp-tool-contract.md)). A few tools are
+non-player-keyed (platform- or region-scoped) — see
+[ADR-0014](../docs/knowledge/decisions/ADR-0014-non-player-keyed-tools.md).
 
 | Tool class (`adapter.in.mcp`) | MCP tool names | Purpose |
 |---|---|---|
@@ -22,6 +24,12 @@ never has to chain `account → summoner → match` itself (see
 | **LiveGameTool** | `lol_spectator_current_game_by_player` | Live-game (Spectator-V5) data; `null` when not in a game |
 | **AnalyticsTool** | `lol_analytics_player_matches` | Aggregated recent-match analytics (composes account + summoner + match) |
 | **LeagueTool** | `lol_league_entries_by_player`, `lol_league_apex_by_tier` | Ranked entries by player; apex league (CHALLENGER/GRANDMASTER/MASTER) by tier + queue |
+| **ChampionTool** | `lol_champion_rotation` | Current free-to-play champion rotation for a platform (non-player-keyed) |
+| **StatusTool** | `lol_status_platform` | Platform status and incidents (Status-V4, non-player-keyed) |
+| **ChampionMasteryTool** | `lol_champion_mastery_by_player` | Champion mastery for a player; optional top-N by mastery points |
+| **ChallengesTool** | `lol_challenges_by_player` | Challenges progress and points for a player |
+| **ClashTool** | `lol_clash_by_player` | Clash tournament registrations for a player |
+| **MatchTool** | `lol_match_ids_by_player`, `lol_match_by_id` | Recent match IDs for a player (region-routed, paged); full detail of one match by ID |
 
 ## Quick start
 


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-19-repo-housekeeping-and-actions-design.md`.

- New `/housekeeping` skill (reusable maintenance audit; `--audit-only` + apply).
- **PR reviewer fixed**: canonical posting form (gh pr comment + inline-comment tool, `pull-requests: write`, draft-skip) — replaces the plugin-slash-command config that ran green but posted nothing.
- `@claude` granted `pull-requests: write` + `issues: write`.
- New weekly commit-gated `housekeeping.yml` that opens a PR (flat OAuth seat).
- `live-eval` `paths-ignore` skips metered runs on docs/skill-only merges (full×both retained for code/eval/workflow).
- Dogfood drift fixes (6→13 tools, 11-class enumeration, ADR-0014 linked) + ADR-0015 + roadmap row closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)