### PR TITLE
ci(housekeeping): concurrency guard + register the workflow

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -5,6 +5,13 @@ on:
     - cron: '0 9 * * 1'   # Mondays 09:00 UTC
   workflow_dispatch:        # manual runs always proceed (bypass the commit gate)
 
+# Never let two housekeeping runs race on the same branch (e.g. a manual dispatch during a
+# scheduled run, or two scheduled runs in one week). Queue rather than cancel — a half-finished
+# maintenance pass shouldn't be killed mid-edit.
+concurrency:
+  group: weekly-housekeeping
+  cancel-in-progress: false
+
 # Least-privilege; elevate only where needed.
 permissions:
   contents: read


### PR DESCRIPTION
Adds a top-level `concurrency` guard to the weekly housekeeping workflow (queue overlapping runs instead of racing on the same week's branch).

**Why now:** `housekeeping.yml`'s introducing merge (#56) had its `push` event dropped by GitHub, so the workflow never registered — `gh workflow run` 404s and, more importantly, its **weekly schedule can't fire**. This PR touches the file, so merging it registers the workflow. Once merged I'll run the manual smoke test to confirm the end-to-end path (gate → skill run → PR-or-no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)