### PR TITLE
perf(eval): cut live-eval token cost from ~$2.60 to $0.33 per dispatch

### DIFF
--- a/.claude/skills/add-live-eval/SKILL.md
+++ b/.claude/skills/add-live-eval/SKILL.md
@@ -28,6 +28,12 @@ Read `docs/knowledge/patterns/live-eval-harness.md` and
    `cd eval && cp mcpeval.stdio.yaml mcpeval.yaml && uv run mcp-eval run tests/<file>.py -v`
    (needs `ANTHROPIC_API_KEY`, `RIOT_API_KEY`, and `LOL_MCP_JAR` — see `eval/README.md`).
 5. **Keep it under budget.** `max_concurrency` stays 1; avoid adding many high-fanout tests.
+6. **Decide whether it belongs in `eval/smoke.txt`.** The `sse` leg runs only that small transport
+   smoke set, not the full suite (ADR-0017). Add your new scenario to `smoke.txt` **only** if it
+   proves something transport-specific — a handshake/discovery check, a round-trip on a newly added
+   server, or error propagation over the wire. A tool-logic scenario does not belong there: the
+   `stdio` leg already covers tool logic, and every entry in `smoke.txt` is paid for on every
+   dispatch of the `sse` leg.
 
 ## Rules
 
@@ -35,5 +41,6 @@ Read `docs/knowledge/patterns/live-eval-harness.md` and
 - A CANARY failure means "investigate a Riot behavior change" first, not "loosen the rubric".
 - Agent-driven only — no direct-call tests here; the WireMock suite owns the deterministic contract.
 
-See [`docs/knowledge/patterns/live-eval-harness.md`](../../../docs/knowledge/patterns/live-eval-harness.md)
-and [`ADR-0012`](../../../docs/knowledge/decisions/ADR-0012-live-eval-harness.md).
+See [`docs/knowledge/patterns/live-eval-harness.md`](../../../docs/knowledge/patterns/live-eval-harness.md),
+[`ADR-0012`](../../../docs/knowledge/decisions/ADR-0012-live-eval-harness.md), and
+[`ADR-0017`](../../../docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md).

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+*.txt text eol=lf

--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -138,8 +138,18 @@ jobs:
           # the file. Restricted to our vars so nothing else is touched.
           envsubst '${LOL_MCP_JAR} ${TFT_MCP_JAR} ${LOL_DEV_API_KEY} ${TFT_DEV_API_KEY} ${LOL_MCP_SSE_URL} ${TFT_MCP_SSE_URL}' \
             < "mcpeval.${{ matrix.transport }}.yaml" > mcpeval.yaml
+          # stdio carries the full suite; sse runs only the transport smoke set,
+          # since both legs otherwise pay for an identical result (ADR-0017).
+          # mcp-eval has no -k/marker selection, so the subset is explicit paths.
+          if [ "${{ matrix.transport }}" = "sse" ]; then
+            mapfile -t SPECS < <(grep -vE '^\s*(#|$)' smoke.txt)
+            echo "EVAL_SCOPE=transport smoke set (${#SPECS[@]} tasks)" >> "$GITHUB_ENV"
+          else
+            SPECS=(tests/)
+            echo "EVAL_SCOPE=full suite" >> "$GITHUB_ENV"
+          fi
           set +e
-          uv run mcp-eval run tests/ -v \
+          uv run mcp-eval run "${SPECS[@]}" -v \
             --json "test-reports/${{ matrix.transport }}.json" \
             --html "test-reports/${{ matrix.transport }}.html" \
             --markdown "test-reports/${{ matrix.transport }}.md"
@@ -151,13 +161,17 @@ jobs:
         working-directory: eval
         run: |
           {
-            echo "## Live eval — ${{ matrix.transport }}"
+            echo "## Live eval — ${{ matrix.transport }} (${EVAL_SCOPE:-unknown scope})"
             if [ "${EVAL_EXIT:-1}" = "0" ]; then
               echo "✅ All live evals passed."
             else
               echo "❌ Live evals reported failures (exit ${EVAL_EXIT})."
               echo ""
               echo "Triage: a **CANARY** failure means Riot's live behavior may have changed — investigate the adapter's assumption before editing the test. A non-canary failure is a regression. Rate-limit / network / Riot 5xx errors are infra flakes — re-run the workflow."
+            fi
+            if [ "${{ matrix.transport }}" = "sse" ]; then
+              echo ""
+              echo "> This leg runs the **transport smoke set** (\`eval/smoke.txt\`), not the full suite. Tool-logic coverage comes from the stdio leg."
             fi
             echo ""
             echo "See the uploaded \`mcpeval-reports-${{ matrix.transport }}\` artifact (Markdown/HTML/JSON) for per-test detail."

--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -143,6 +143,13 @@ jobs:
           # mcp-eval has no -k/marker selection, so the subset is explicit paths.
           if [ "${{ matrix.transport }}" = "sse" ]; then
             mapfile -t SPECS < <(grep -vE '^\s*(#|$)' smoke.txt)
+            # Fail loudly on an empty smoke set: mcp-eval's test_dir argument defaults
+            # to "tests", so passing no specs would silently run the FULL suite on this
+            # leg while the summary still claimed a 0-task smoke run.
+            if [ "${#SPECS[@]}" -eq 0 ]; then
+              echo "::error::eval/smoke.txt has no runnable specs — refusing to fall through to the full suite."
+              exit 1
+            fi
             echo "EVAL_SCOPE=transport smoke set (${#SPECS[@]} tasks)" >> "$GITHUB_ENV"
           else
             SPECS=(tests/)

--- a/.github/workflows/live-eval.yml
+++ b/.github/workflows/live-eval.yml
@@ -150,7 +150,17 @@ jobs:
               echo "::error::eval/smoke.txt has no runnable specs — refusing to fall through to the full suite."
               exit 1
             fi
-            echo "EVAL_SCOPE=transport smoke set (${#SPECS[@]} tasks)" >> "$GITHUB_ENV"
+            # Fail loudly on a *stale* spec too: a renamed test function, a moved file, or
+            # smoke.txt recommitted with CRLF (stripped by .gitattributes going forward, but
+            # guard anyway) would leave the array non-empty while mcp-eval silently skips the
+            # unresolvable paths — the leg would run ~zero tasks, exit green, and the summary
+            # would still claim full smoke coverage.
+            for s in "${SPECS[@]}"; do
+              f="${s%%::*}"; fn="${s##*::}"
+              [ -f "$f" ] || { echo "::error::stale smoke spec, no such file: $s"; exit 1; }
+              grep -q "def ${fn}(" "$f" || { echo "::error::stale smoke spec, no such function: $s"; exit 1; }
+            done
+            echo "EVAL_SCOPE=transport smoke set (${#SPECS[@]} specs)" >> "$GITHUB_ENV"
           else
             SPECS=(tests/)
             echo "EVAL_SCOPE=full suite" >> "$GITHUB_ENV"
@@ -172,7 +182,7 @@ jobs:
             if [ "${EVAL_EXIT:-1}" = "0" ]; then
               echo "✅ All live evals passed."
             else
-              echo "❌ Live evals reported failures (exit ${EVAL_EXIT})."
+              echo "❌ Live evals reported failures (exit ${EVAL_EXIT:-unset — guard failed before mcp-eval ran})."
               echo ""
               echo "Triage: a **CANARY** failure means Riot's live behavior may have changed — investigate the adapter's assumption before editing the test. A non-canary failure is a regression. Rate-limit / network / Riot 5xx errors are infra flakes — re-run the workflow."
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ both.
   tool logic for no added signal. The `stdio` leg is unchanged (full suite). See
   [ADR-0017](docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md).
 - **`eval/tools/report-cost.py`** — sums a live-eval JSON report's real token counts and prices them
-  at Claude Haiku 4.5's actual rates, since the report's own `cost_estimate` field understates the
-  bill and omits LLM-judge tokens (see `docs/knowledge/gotchas.md`).
+  at Claude Haiku 4.5's actual rates, since the report's own `cost_estimate` field prices at a
+  ~$0.50/MTok fallback rate that understates the bill by roughly 2×. It reads the same judge-blind
+  raw metrics `cost_estimate` does, so LLM-judge tokens remain unmeasured by either number (see
+  `docs/knowledge/gotchas.md`).
 
 ### Changed
 - The `Summarize outcome` step of `live-eval.yml` now names each leg's coverage scope (`full suite`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Repo-wide changes only: build tooling, CI, the module graph, and root documentation.
 
 **Per-module history lives with the module** — [`riot-api-core`](riot-api-core/CHANGELOG.md),
-[`riot-account-core`](riot-account-core/CHANGELOG.md), [`lol-mcp-server`](lol-mcp-server/CHANGELOG.md).
+[`riot-account-core`](riot-account-core/CHANGELOG.md), [`lol-mcp-server`](lol-mcp-server/CHANGELOG.md),
+[`tft-mcp-server`](tft-mcp-server/CHANGELOG.md).
 Each is independently versioned and tagged (`<module>/v<semver>`); see
 [ADR-0010](docs/knowledge/decisions/ADR-0010-versioning-and-coordinates.md).
 
@@ -13,6 +14,28 @@ covers only changes that bump no module.
 Entries below predate the per-module split and are kept as the repository's history to that point.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Live-eval token cost reduction
+
+Repo-wide changes only — the two MCP tool behavior changes that reduce per-call token cost are
+logged in [`lol-mcp-server`](lol-mcp-server/CHANGELOG.md)'s and
+[`tft-mcp-server`](tft-mcp-server/CHANGELOG.md)'s own changelogs (they bump those modules); see
+[ADR-0016](docs/knowledge/decisions/ADR-0016-bounded-list-results.md) for the rationale shared by
+both.
+
+### Added
+- **`eval/smoke.txt`** — an explicit, small transport smoke set that the `sse` leg of
+  `live-eval.yml` now runs instead of the full suite, since both legs previously exercised identical
+  tool logic for no added signal. The `stdio` leg is unchanged (full suite). See
+  [ADR-0017](docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md).
+- **`eval/tools/report-cost.py`** — sums a live-eval JSON report's real token counts and prices them
+  at Claude Haiku 4.5's actual rates, since the report's own `cost_estimate` field understates the
+  bill and omits LLM-judge tokens (see `docs/knowledge/gotchas.md`).
+
+### Changed
+- The `Summarize outcome` step of `live-eval.yml` now names each leg's coverage scope (`full suite`
+  vs `transport smoke set (N tasks)`) in the job summary, so a green `sse` run is never misread as
+  full tool-logic coverage.
 
 ## sub-project 1a Plan D — per-module docs and the monorepo sanity check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,10 @@ touching stdio logging. Full detail and diagrams: [ARCHITECTURE.md](ARCHITECTURE
 
 - **DTOs:** `@Data @Builder @NoArgsConstructor @AllArgsConstructor` + `@JsonIgnoreProperties(ignoreUnknown = true)`.
   Nested `@Builder` static classes also need `@NoArgsConstructor @AllArgsConstructor` (see
-  `gotchas.md`).
+  `gotchas.md`). Adding a new primitive field to an existing Riot-mapped DTO needs
+  `@NoArgsConstructor(onConstructor_ = @JsonCreator)` instead, or deserialization breaks on payloads
+  missing that field — see the gotcha "Adding a primitive field to an existing Riot-mapped DTO breaks
+  its adapter test".
 - **Ports:** interfaces in `<context>.application.port`, named `<Context>Port`. Services depend on
   the port, never on a `RestClient`.
 - **Tools:** `@McpTool` methods in `<context>.adapter.in.mcp` with stable snake_case names; delegate

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -35,6 +35,8 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [ADR-0013 — Remove the featured-games tool (endpoint retired by Riot)](decisions/ADR-0013-remove-featured-games.md)
 - [ADR-0014 — Non-player-keyed tools extend the tool contract](decisions/ADR-0014-non-player-keyed-tools.md)
 - [ADR-0015 — Repository maintenance automation](decisions/ADR-0015-repo-maintenance-automation.md)
+- [ADR-0016 — Bounded list results for MCP tools](decisions/ADR-0016-bounded-list-results.md)
+- [ADR-0017 — Transport-scoped live eval coverage](decisions/ADR-0017-transport-scoped-live-eval.md)
 
 ### Patterns
 

--- a/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
+++ b/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
@@ -1,0 +1,62 @@
+# ADR-0016: Bounded list results for MCP tools
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+
+## Context
+
+`lol_league_apex_by_tier` returned the entire CHALLENGER ladder — roughly 300 entries, ~17,900
+tokens per call. Because it typically lands on turn 1 of a 3–4 iteration agent chain and is
+re-sent as context on every subsequent iteration, it accounted for ~58% of all live-eval input
+tokens (measured on run `30011353019`: 1,250,624 input tokens per transport).
+`lol_challenges_by_player` had the same shape: a ~150-token useful head (`totalPoints`,
+`categoryPoints`) followed by a `challenges[]` array of ~500 rows that was ~99% of the payload.
+
+Neither is an eval-only problem. A tool whose default response is ~18,000 tokens is bad MCP design
+for any consumer, human or agent; the live eval only made the cost visible.
+
+## Decision
+
+Add an optional `count` param, with a **capped default of 10**, to:
+
+- `lol_league_apex_by_tier`
+- `tft_league_apex_by_tier`
+- `lol_challenges_by_player`
+
+Each response also stamps the pre-truncation size: `totalEntries` on the two league tools,
+`totalChallenges` on challenges. A caller that received the capped list can still see the true
+ladder/challenge count.
+
+**Why a capped default rather than an opt-in param:** an opt-in leaves the naive call — the one a
+real agent makes when it does not know to ask for a smaller page — at ~18k tokens, and would have
+forced every existing eval prompt to be rewritten to add the param. Capping the default fixed the
+cost with zero eval-prompt churn; a caller that wants more still can.
+
+**Why the application layer, not the adapter:** Riot's League-V4 apex endpoint, TFT-League-V1's
+apex endpoint, and LoL-Challenges-V1 have **no server-side count parameter** — the truncation has
+to happen somewhere in our code, not Riot's. This differs from Champion-Mastery-V4, where
+`ChampionMasteryService` pushes `count` down to the port because Riot's mastery endpoint *does*
+accept one. Same MCP-level contract (an optional `count`, a sane default) implemented at whichever
+layer matches what Riot supports — the port when Riot can filter server-side, the service when it
+cannot. Adapters stay dumb mappers either way, and the hexagon rules (`adapter → application →
+domain`) hold.
+
+**Ordering:** Riot does not guarantee entry order, so entries are sorted before slicing —
+`leaguePoints` descending for the two league tools, challenge `percentile` ascending (rarer first)
+for challenges — with a null-safe comparator in both cases (TFT's `leaguePoints` is a boxed
+`Integer` and Riot may omit it; challenge `percentile` is absent on challenges a player has not
+progressed on). Without sorting first, "top N" is meaningless and a discovered eval subject would
+change between runs of the same test.
+
+## Consequences
+
+- A behavior change to three published tools: they now return fewer entries by default. Tool names
+  and existing param descriptions are unchanged; `count` and the `total*` fields are additive.
+  Logged in the `lol-mcp-server` and `tft-mcp-server` changelogs.
+- `tft_league_rated_ladder_by_queue` and `tft_league_by_id` remain **known-unbounded** — no eval
+  exercises either, so capping them was out of scope for this change. The same remedy (a capped
+  `count` at whichever layer Riot's endpoint supports) applies if either ever shows up in a token
+  budget. `tft_league_by_id` does stamp `totalEntries` for response-shape consistency with the apex
+  tools, but it deliberately neither slices nor reorders its `entries`.
+- `lol_match_by_id` / `tft_match_by_id` are explicitly out of scope: full match detail is that
+  tool's contract, and capping it would gut the response it exists to provide.

--- a/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
+++ b/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
@@ -43,9 +43,11 @@ domain`) hold.
 
 **Ordering:** Riot does not guarantee entry order, so entries are sorted before slicing —
 `leaguePoints` descending for the two league tools, challenge `percentile` ascending (rarer first)
-for challenges — with a null-safe comparator in both cases (TFT's `leaguePoints` is a boxed
-`Integer` and Riot may omit it; challenge `percentile` is absent on challenges a player has not
-progressed on). Without sorting first, "top N" is meaningless and a discovered eval subject would
+for challenges. Two of the three sorts need a **null-safe** comparator and one does not, and the
+difference is the field's declared type: TFT's `leaguePoints` is a boxed `Integer` that Riot may
+omit, and challenge `percentile` is absent on challenges a player has not progressed on, so both
+sort nulls last; LoL's `leaguePoints` is a primitive `int`, so `comparingInt` is safe there and no
+null handling is needed. Without sorting first, "top N" is meaningless and a discovered eval subject would
 change between runs of the same test.
 
 ## Consequences

--- a/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
+++ b/docs/knowledge/decisions/ADR-0016-bounded-list-results.md
@@ -36,19 +36,43 @@ cost with zero eval-prompt churn; a caller that wants more still can.
 apex endpoint, and LoL-Challenges-V1 have **no server-side count parameter** — the truncation has
 to happen somewhere in our code, not Riot's. This differs from Champion-Mastery-V4, where
 `ChampionMasteryService` pushes `count` down to the port because Riot's mastery endpoint *does*
-accept one. Same MCP-level contract (an optional `count`, a sane default) implemented at whichever
-layer matches what Riot supports — the port when Riot can filter server-side, the service when it
-cannot. Adapters stay dumb mappers either way, and the hexagon rules (`adapter → application →
+accept one. Adapters stay dumb mappers either way, and the hexagon rules (`adapter → application →
 domain`) hold.
 
+**Champion mastery does *not* share this ADR's MCP-level contract — it only shares the parameter
+name.** `ChampionMasteryService.getMasteryByPlayer` and `RiotChampionMasteryAdapter.getMasteryByPuuid`
+forward `count` to Riot untouched (`.../top?count=" + count` when non-null, the unfiltered endpoint
+otherwise):
+
+- **No default.** A `null` count returns every mastery entry Riot has for the player — there is no
+  10-entry fallback like the three tools above.
+- **No zero/negative clamping.** `count` goes straight into the URL; whatever Riot does with `0` or a
+  negative value is what the caller gets. The three tools this ADR governs explicitly clamp
+  non-positive counts to the default (see the tests) — mastery has no equivalent guard.
+
+This is a real inconsistency in the MCP surface, not a documentation nuance: an agent calling
+`lol_champion_mastery_by_player` with no `count` gets an unbounded response, while the same shape of
+call to the other three tools is capped. Aligning mastery (a default + clamping, applied in the
+service so the port's pass-through stays simple) is a reasonable follow-up, but it is out of scope
+for this branch — do not change the mastery code here.
+
 **Ordering:** Riot does not guarantee entry order, so entries are sorted before slicing —
-`leaguePoints` descending for the two league tools, challenge `percentile` ascending (rarer first)
-for challenges. Two of the three sorts need a **null-safe** comparator and one does not, and the
-difference is the field's declared type: TFT's `leaguePoints` is a boxed `Integer` that Riot may
-omit, and challenge `percentile` is absent on challenges a player has not progressed on, so both
-sort nulls last; LoL's `leaguePoints` is a primitive `int`, so `comparingInt` is safe there and no
-null handling is needed. Without sorting first, "top N" is meaningless and a discovered eval subject would
-change between runs of the same test.
+`leaguePoints` descending for the two league tools, challenge `percentile` ascending for challenges.
+Two of the three sorts need a **null-safe** comparator and one does not, and the difference is the
+field's declared type: TFT's `leaguePoints` is a boxed `Integer` that Riot may omit, and challenge
+`percentile` is absent on challenges a player has not progressed on, so both sort nulls last; LoL's
+`leaguePoints` is a primitive `int`, so `comparingInt` is safe there and no null handling is needed.
+Without sorting first, "top N" is meaningless and a discovered eval subject would change between
+runs of the same test.
+
+**Open question — is "lower percentile = rarer/stronger" actually true?** The ascending-by-percentile
+sort (and the original "10 strongest challenges" framing) rests on an assumption that a lower
+`percentile` value means a rarer, more impressive achievement. This has **not been verified** against
+a live Riot response or the developer portal — only that the comparator sorts ascending as coded; the
+tests prove the mechanism, not the interpretation. If Riot's semantics are inverted, the tool returns
+the player's ten *weakest* challenges instead, and every existing test would still pass. See the
+gotchas entry for the open question. If it does invert, the fix is one comparator direction plus this
+tool's description — no architectural change.
 
 ## Consequences
 

--- a/docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md
+++ b/docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md
@@ -1,0 +1,56 @@
+# ADR-0017: Transport-scoped live eval coverage
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+
+## Context
+
+`live-eval.yml` runs a matrix of `stdio` and `sse`, and both legs ran the identical 24-task suite.
+On run `30011353019` the two legs produced identical outcomes and agreed on token spend within
+0.03%. That makes sense: the same server jars, the same Riot responses, and the same tool logic sit
+underneath both transports — only the wire protocol between the eval agent and the server differs.
+Running the full suite on both legs pays for one signal twice.
+
+## Decision
+
+- The `stdio` leg keeps running the **full suite** (`eval/tests/`) — this is the leg that proves
+  tool logic and catches regressions.
+- The `sse` leg runs a small, explicit **transport smoke set** listed in `eval/smoke.txt`: a
+  handshake/discovery check, one round-trip tool call per server (LoL and TFT each have their own
+  port), and one error-propagation case. Four tasks total.
+
+## Mechanism
+
+`mcp-eval run` takes positional path specs, including `file.py::function_name`, but has **no `-k`,
+marker, or tag selection** (verified against `mcp_eval/runner.py` in mcp-eval 0.1.10). Scoping the
+`sse` leg therefore means passing it an explicit list of specs rather than filtering the full suite
+by attribute. `eval/smoke.txt` holds that list — one spec per line, `#` comments and blank lines
+ignored — read by the workflow and passed as positional arguments to `mcp-eval run`. It lives next
+to the tests, not inline in the CI YAML, so it stays visible to anyone adding a test.
+
+The workflow fails loudly if `smoke.txt` resolves to zero specs, rather than falling through to
+`mcp-eval`'s default `test_dir` of `"tests"` — see the "stale smoke set" gotcha and the matching
+triage row for why an empty smoke set is a hazard, not just a no-op.
+
+## What the sse leg does not prove
+
+Any tool-logic regression. That coverage comes entirely from the `stdio` leg. The job summary
+names the running leg's scope (`full suite` vs `transport smoke set (N tasks)`) so a green `sse`
+run is never misread as full coverage.
+
+## Relationship to ADR-0012
+
+This narrows the coverage matrix established by [ADR-0012](ADR-0012-live-eval-harness.md); the
+harness's purpose (agent-driven, live-Riot, post-merge, non-gating), credential model
+(`ANTHROPIC_API_KEY` only), and per-server dev-key handling are all unchanged.
+
+## Consequences
+
+- Every dispatch pays for four `sse` tasks instead of 24, cutting that leg's token spend
+  proportionally (see [ADR-0016](ADR-0016-bounded-list-results.md) for the companion per-tool
+  payload reduction).
+- A new transport-specific behavior (e.g. a new server, a new error-propagation path) needs its own
+  smoke entry; a new tool-logic scenario does not — see the `add-live-eval` skill.
+- `smoke.txt` is now a second place (besides the test files themselves) that can go stale: a
+  renamed test or function silently drops out of the smoke leg. See the matching gotcha and triage
+  row in the harness pattern guide.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -296,3 +296,16 @@ dependency, not as "install Rust." This cost two subagents time on this project 
 found. If the venv is already built (e.g. by CI, or by a prior successful `uv sync` elsewhere), use
 `uv run --no-sync` against it instead of re-resolving; only run a full `uv sync` on a box that either
 already has a Rust toolchain or reliably resolves to prebuilt wheels.
+
+## Open question: does a lower challenge `percentile` mean rarer/stronger, or the opposite?
+
+`ChallengesService.boundChallenges` sorts `lol_challenges_by_player`'s per-challenge list by
+`percentile` **ascending**, on the assumption that a lower percentile is a rarer, more impressive
+achievement — so the capped top-10 view is framed as the player's "strongest" challenges. This
+assumption has **not been verified** against a live Riot response or the developer portal. The unit
+tests only prove the comparator sorts ascending as coded; nothing in the suite establishes which
+direction actually corresponds to "rarer" in Riot's data. If the semantics are inverted, the tool
+silently returns the player's ten *weakest* challenges instead, and every existing test still passes
+— this is not something offline tests can catch, only a live response or the portal docs can settle
+it. If you resolve this, the fix (if needed) is a one-line comparator direction change plus updating
+`ChallengesTool`'s description; no architectural change. See ADR-0016's ordering section.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -202,7 +202,10 @@ primitive rejects it — `Cannot map null into type int`. The symptom is an **ex
 passing WireMock adapter test failing on a commit that never touched the adapter**, which reads like
 the change went into the wrong layer when it did not.
 
-Hit in sub-project 3 adding the domain-computed `totalEntries` to `league`'s `LeagueList`.
+Hit in sub-project 3 adding the domain-computed `totalEntries` to `league`'s `LeagueList`, and again
+in the live-eval token cost work adding `totalEntries` to TFT's `LeagueList` and `totalChallenges` to
+`challenges`' `ChallengesPlayerData` — same fix, three DTOs, same otherwise-unrelated-looking test
+failure each time.
 
 **Fix:** annotate the no-args constructor as the creator —
 `@NoArgsConstructor(onConstructor_ = @JsonCreator)` — which forces bean-style deserialization for the
@@ -253,3 +256,37 @@ any trivial follow-up commit to `master` (or merge a one-line PR) to generate a 
 that re-triggers the missing runs and registers the new workflow. Don't debug repo settings first;
 confirm with `gh api "repos/<owner>/<repo>/actions/runs?head_sha=<sha>" --jq '.total_count'` (0 = the
 event was dropped) and check <https://www.githubstatus.com> before assuming a config problem.
+
+## mcp-eval's `cost_estimate` understates the bill by ~2× and omits judge tokens
+
+The report's own `cost_estimate` field prices at a ~$0.50/MTok fallback rate; the harness actually
+runs on Claude Haiku 4.5, which is $1.00/MTok input and $5.00/MTok output — roughly double the
+fallback on input alone. It also counts only agent-loop spans, not the separate LLM-judge call each
+`Expect.judge.llm(...)` assertion makes: verified by arithmetic, `test_status_platform`'s 5,975
+input tokens are exactly accounted for by the agent's two tool-calling iterations, with nothing left
+over for a judge call. Read token counts from the report's raw `metrics` via
+`eval/tools/report-cost.py` (see [the harness guide](patterns/live-eval-harness.md#measure-the-cost)),
+not the `cost_estimate` field, when you actually need to know what a run cost.
+
+## Never ask an LLM judge to verify something the prompt did not request
+
+`test_champion_mastery_for_discovered_player` asked the agent for *"the top champion"* (singular)
+while its rubric graded *"reports at most 3 champion mastery entries"* — a mismatch between what
+the prompt asked for and what the rubric checked. The judge sees only the rubric and the response,
+never the original prompt, so it penalised the agent for correctly obeying the singular instruction
+— failing on `stdio` and passing on `sse` purely on judge variance, with nothing in the code having
+changed. Two lessons: assert tool arguments **structurally** with `Expect.tools.called_with(...)`
+(subset matching, zero judge tokens, deterministic) wherever the thing you actually want to check is
+"did the tool get called with the right args", and keep judge rubrics scoped to exactly what the
+prompt asked for — nothing broader.
+
+## `uv sync` cannot build `litellm`'s Rust-backed dependencies on a bare Windows box
+
+`eval/`'s `uv.lock` pins `litellm`, which pulls in `tokenizers` (HuggingFace's Rust-backed tokenizer
+library). PyPI ships prebuilt wheels for common platforms, but if the resolved set falls back to a
+source build for any of them, `uv sync` needs a Rust toolchain (`cargo`) to compile it — one is not
+present on a stock Windows dev box, and the failure surfaces as a build error deep in a transitive
+dependency, not as "install Rust." This cost two subagents time on this project before the cause was
+found. If the venv is already built (e.g. by CI, or by a prior successful `uv sync` elsewhere), use
+`uv run --no-sync` against it instead of re-resolving; only run a full `uv sync` on a box that either
+already has a Rust toolchain or reliably resolves to prebuilt wheels.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -257,16 +257,22 @@ that re-triggers the missing runs and registers the new workflow. Don't debug re
 confirm with `gh api "repos/<owner>/<repo>/actions/runs?head_sha=<sha>" --jq '.total_count'` (0 = the
 event was dropped) and check <https://www.githubstatus.com> before assuming a config problem.
 
-## mcp-eval's `cost_estimate` understates the bill by ~2× and omits judge tokens
+## mcp-eval's `cost_estimate` understates the bill by ~2× — and neither it nor `report-cost.py` sees judge tokens
 
 The report's own `cost_estimate` field prices at a ~$0.50/MTok fallback rate; the harness actually
 runs on Claude Haiku 4.5, which is $1.00/MTok input and $5.00/MTok output — roughly double the
-fallback on input alone. It also counts only agent-loop spans, not the separate LLM-judge call each
-`Expect.judge.llm(...)` assertion makes: verified by arithmetic, `test_status_platform`'s 5,975
-input tokens are exactly accounted for by the agent's two tool-calling iterations, with nothing left
-over for a judge call. Read token counts from the report's raw `metrics` via
-`eval/tools/report-cost.py` (see [the harness guide](patterns/live-eval-harness.md#measure-the-cost)),
-not the `cost_estimate` field, when you actually need to know what a run cost.
+fallback on input alone. `eval/tools/report-cost.py` fixes that *rate* error by repricing the
+report's raw token counts at Haiku 4.5's real rates.
+
+It does not fix a separate problem: those raw metrics count only agent-loop spans, not the separate
+LLM-judge call each `Expect.judge.llm(...)` assertion makes — verified by arithmetic,
+`test_status_platform`'s 5,975 input tokens are exactly accounted for by the agent's two
+tool-calling iterations, with nothing left over for a judge call. Judge token spend is therefore
+**unmeasured by both numbers**, `cost_estimate` and `report-cost.py` alike — an open omission, not
+something the rate fix solves. Read token counts from the report's raw `metrics` via
+`eval/tools/report-cost.py` (see [the harness guide](patterns/live-eval-harness.md#measure-the-cost))
+for an accurate rate; know that it still excludes judge spend when you need the true total cost of a
+run.
 
 ## Never ask an LLM judge to verify something the prompt did not request
 

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -192,6 +192,25 @@ that feeds `null` for the nullable-looking fields and asserts it parses — that
 of failure offline instead of waiting for the post-merge live eval. Boxing `boolean`→`Boolean` also
 renames the Lombok getter (`isX()` → `getX()`); update call sites.
 
+## Adding a primitive field to an existing Riot-mapped DTO breaks its adapter test
+
+The boxing rule above covers Riot fields that come back explicitly `null`. There is a second, more
+surprising trigger: adding a **new primitive field that is not on the wire at all**. Once a DTO has
+both `@NoArgsConstructor` and `@AllArgsConstructor`, Jackson treats the all-args constructor as an
+implicit properties-based creator; a field missing from the JSON is then passed as `null`, and a
+primitive rejects it — `Cannot map null into type int`. The symptom is an **existing, previously
+passing WireMock adapter test failing on a commit that never touched the adapter**, which reads like
+the change went into the wrong layer when it did not.
+
+Hit in sub-project 3 adding the domain-computed `totalEntries` to `league`'s `LeagueList`.
+
+**Fix:** annotate the no-args constructor as the creator —
+`@NoArgsConstructor(onConstructor_ = @JsonCreator)` — which forces bean-style deserialization for the
+whole class, so absent fields simply keep their default. Boxing works too, but a count that is always
+computed by us reads better as an `int`. **First, though, ask whether the derived field belongs on a
+wire-format DTO at all**; here it does, because the truncating service and the tool response share one
+type.
+
 ## Riot's live JSON field names can differ from the developer-portal docs
 
 Champion-V3 `/lol/platform/v3/champion-rotations` is documented as returning `freeChampionIds`,

--- a/docs/knowledge/patterns/live-eval-harness.md
+++ b/docs/knowledge/patterns/live-eval-harness.md
@@ -6,6 +6,11 @@ sse. It runs on demand via `workflow_dispatch` (`.github/workflows/live-eval.yml
 `gh workflow run live-eval.yml [--ref <branch>]` — and never gates a merge. See
 [ADR-0012](../decisions/ADR-0012-live-eval-harness.md) for why.
 
+The two legs are not scoped the same: `stdio` runs the **full suite** (`eval/tests/`); `sse` runs
+only the four-task transport smoke set in `eval/smoke.txt` (handshake/discovery, one round-trip per
+server, error propagation). See [ADR-0017](../decisions/ADR-0017-transport-scoped-live-eval.md) for
+why, and add to `smoke.txt` only when a new scenario proves something transport-specific.
+
 ## Run locally
 
 Prerequisites: `uv`, an `ANTHROPIC_API_KEY`, and **one Riot dev key per server** — each game's Riot
@@ -45,6 +50,22 @@ failing run by outcome class:
 | infra-flake | rate-limit / network / Riot 5xx | re-run the workflow |
 | regression | non-canary assertion failed | a change broke a tool — fix it |
 | canary-drift | a `CANARY:` task failed | investigate a Riot behavior change *before* editing the test |
+| stale smoke set | a spec in `eval/smoke.txt` no longer resolves (renamed test/function) — `mcp-eval` prints `Skipping missing path` and the `sse` leg silently runs fewer tasks | fix or remove the stale spec in `smoke.txt` |
+
+## Measure the cost
+
+Report `cost_estimate` is unreliable — see
+[the gotcha](../gotchas.md#mcp-evals-cost_estimate-understates-the-bill-by-2-and-omits-judge-tokens).
+Get the real per-run token spend and pricing from the raw report instead:
+
+```bash
+cd eval && uv run python tools/report-cost.py test-reports/stdio.json
+# or both legs together:
+cd eval && uv run python tools/report-cost.py test-reports/stdio.json test-reports/sse.json
+```
+
+This prints per-test and per-tool token tables plus a total priced at Claude Haiku 4.5's real rates
+($1.00/MTok input, $5.00/MTok output) — the figures behind [ADR-0016](../decisions/ADR-0016-bounded-list-results.md).
 
 ## Add coverage
 

--- a/docs/superpowers/plans/2026-07-23-live-eval-token-cost.md
+++ b/docs/superpowers/plans/2026-07-23-live-eval-token-cost.md
@@ -1,0 +1,1506 @@
+# Live-Eval Token Cost Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut live-eval token spend from ~$2.60 to ≤$0.35 per dispatch by bounding three oversized MCP tool payloads and scoping the `sse` leg to a transport smoke set, then measure the result against a captured baseline.
+
+**Architecture:** Three MCP tools gain an optional `count` parameter with a capped default; truncation happens in the **application service** (Riot's League-V4 / TFT-League-V1 / Challenges-V1 endpoints have no server-side count param, unlike Champion-Mastery-V4 which truncates at the port). Outbound adapters are untouched. The eval harness gains an explicit smoke-set file because `mcp-eval` has no marker/`-k` selection, plus a committed cost-report script.
+
+**Tech Stack:** Java 21, Spring Boot 4.1, Spring AI 2.0, Lombok, Gradle, JUnit 5, AssertJ, Mockito, WireMock; Python 3.11 + `mcpevals` 0.1.10 (`uv`) for the eval harness; GitHub Actions.
+
+**Spec:** [`docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md`](../specs/2026-07-23-live-eval-token-cost-design.md)
+
+## Global Constraints
+
+- **The offline suite must stay key-free and network-free.** `./gradlew build` is the CI gate. Never add a test needing `RIOT_API_KEY` or network access — use WireMock (adapters) or in-memory port fakes (services).
+- **Dependency rule:** servers → `riot-account-core` → `riot-api-core`, never back. Within a module: `adapter → application → domain`, inward only. ArchUnit enforces this.
+- **`RestClient` only in `adapter.out.riot`; `@McpTool` only in `adapter.in.mcp`.** Truncation logic goes in `application`, never in an adapter.
+- **Tool names are the public MCP contract and do not change.** Existing `@McpToolParam` descriptions do not change. New params and updated `@McpTool` descriptions are permitted and required here.
+- **DTO convention:** `@Data @Builder @NoArgsConstructor @AllArgsConstructor` + `@JsonIgnoreProperties(ignoreUnknown = true)`.
+- **Default cap is `10`** for all three bounded tools.
+- **Run `./gradlew spotlessApply` before every Java commit.** The build fails on formatting.
+- **Every commit must leave `./gradlew build` green.**
+
+---
+
+## File Structure
+
+**Java — LoL server (`lol-mcp-server/src/main/java/com/muddl/riot/lol/`)**
+
+| File | Responsibility |
+|---|---|
+| `league/domain/LeagueList.java` | Gains `totalEntries` + `toBuilder` |
+| `league/application/LeagueService.java` | Owns apex truncation + sort |
+| `league/adapter/in/mcp/LeagueTool.java` | Exposes `count` param |
+| `challenges/domain/ChallengesPlayerData.java` | Gains `totalChallenges` + `toBuilder` |
+| `challenges/application/ChallengesService.java` | Owns challenge truncation + sort |
+| `challenges/adapter/in/mcp/ChallengesTool.java` | Exposes `count` param |
+
+**Java — TFT server (`tft-mcp-server/src/main/java/com/muddl/riot/tft/`)**
+
+| File | Responsibility |
+|---|---|
+| `league/domain/LeagueList.java` | Gains `totalEntries` + `toBuilder` |
+| `league/application/LeagueService.java` | Apex truncation; `getLeagueById` stamps total only |
+| `league/adapter/in/mcp/LeagueTool.java` | Exposes `count` param on apex only |
+
+**Eval harness (`eval/`)**
+
+| File | Responsibility |
+|---|---|
+| `smoke.txt` (new) | The sse transport smoke set, one `file.py::func` per line |
+| `tools/report-cost.py` (new) | Token/cost aggregation from a run's JSON report |
+| `tests/test_championmastery.py` | Rubric fix + structural `count` assertion |
+| `tests/test_league.py` | Apex rubric retargeted at `totalEntries` |
+| `README.md` | Documents `smoke.txt` and the cost report |
+
+**CI + docs**
+
+| File | Responsibility |
+|---|---|
+| `.github/workflows/live-eval.yml` | Transport-scoped spec selection + scope-aware summary |
+| `docs/knowledge/decisions/ADR-0016-bounded-list-results.md` (new) | Capped-default rationale |
+| `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md` (new) | Smoke-set rationale |
+| `docs/knowledge/gotchas.md` | Two new entries |
+| `docs/knowledge/patterns/live-eval-harness.md` | Smoke set + cost report |
+| `.claude/skills/add-live-eval/SKILL.md` | Prompt author about `smoke.txt` |
+| `CHANGELOG.md` | Three tool behavior changes |
+
+---
+
+## Task 1: Bound the LoL apex league
+
+**Files:**
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/league/domain/LeagueList.java`
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/league/application/LeagueService.java`
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueTool.java`
+- Test: `lol-mcp-server/src/test/java/com/muddl/riot/lol/league/application/LeagueServiceTest.java`
+- Test: `lol-mcp-server/src/test/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueToolTest.java`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `LeagueList.getTotalEntries()` returns `int` — pre-truncation entry count.
+  - `LeagueService.getApexLeague(RiotApiPlatformUri platform, ApexTier tier, String queue, Integer count)` returns `LeagueList`.
+  - `LeagueTool.getApexLeague(String platformStr, String tierStr, String queueStr, Integer count)` returns `LeagueList`.
+
+**Background for the implementer:** `LeagueItem.getLeaguePoints()` returns a primitive `int`, so `Comparator.comparingInt` is safe with no null handling. `InMemoryLeaguePort.getApexLeague` returns `null` for an unknown key, so the service must guard against a null `LeagueList`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing `getApexLeague_delegatesToPort` test in `LeagueServiceTest.java` (it asserts `isSameAs`, which can no longer hold — the service now returns a bounded copy) and add the new cases. Add these imports to the file: `com.muddl.riot.lol.league.domain.LeagueItem` and `java.util.stream.IntStream`.
+
+```java
+    private static LeagueList ladderOf(int size) {
+        // leaguePoints ascending with index, so the *last* entries are the top ones —
+        // a service that slices without sorting will fail these tests.
+        return LeagueList.builder()
+                .tier("CHALLENGER")
+                .queue("RANKED_SOLO_5x5")
+                .entries(IntStream.range(0, size)
+                        .mapToObj(i -> LeagueItem.builder()
+                                .puuid("puuid-" + i)
+                                .leaguePoints(i)
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Test
+    void getApexLeague_capsAtTen_whenCountIsNull() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
+
+        assertThat(result.getEntries()).hasSize(10);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+        assertThat(result.getTier()).isEqualTo("CHALLENGER");
+    }
+
+    @Test
+    void getApexLeague_sortsByLeaguePointsDescending() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3);
+
+        assertThat(result.getEntries())
+                .extracting(LeagueItem::getLeaguePoints)
+                .containsExactly(299, 298, 297);
+    }
+
+    @Test
+    void getApexLeague_honoursExplicitCount() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 50)
+                        .getEntries())
+                .hasSize(50);
+    }
+
+    @Test
+    void getApexLeague_countExceedingSize_returnsEverything() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(7));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 5000);
+
+        assertThat(result.getEntries()).hasSize(7);
+        assertThat(result.getTotalEntries()).isEqualTo(7);
+    }
+
+    @Test
+    void getApexLeague_zeroOrNegativeCount_clampsToDefault() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 0)
+                        .getEntries())
+                .hasSize(10);
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", -4)
+                        .getEntries())
+                .hasSize(10);
+    }
+
+    @Test
+    void getApexLeague_nullEntries_yieldsEmptyListAndZeroTotal() {
+        leaguePort.putApex(
+                ApexTier.CHALLENGER,
+                "RANKED_SOLO_5x5",
+                LeagueList.builder().tier("CHALLENGER").build());
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
+
+        assertThat(result.getEntries()).isEmpty();
+        assertThat(result.getTotalEntries()).isZero();
+    }
+
+    @Test
+    void getApexLeague_nullLeague_returnsNull() {
+        assertThat(leagueService.getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_SOLO_5x5", null))
+                .isNull();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :lol-mcp-server:test --tests '*league.application.LeagueServiceTest'`
+Expected: FAIL — compilation error, `getApexLeague` cannot be applied to 4 arguments, and `getTotalEntries()` / `LeagueList.builder().totalEntries` do not exist.
+
+- [ ] **Step 3: Add `totalEntries` and `toBuilder` to the domain type**
+
+In `league/domain/LeagueList.java`, change the `@Builder` annotation and add the field:
+
+```java
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeagueList {
+    private String leagueId;
+    private String tier;
+    private String name;
+    private String queue;
+    private List<LeagueItem> entries;
+
+    /**
+     * Total entries in the league before any {@code count} bound was applied. Lets a caller that
+     * received a capped {@link #entries} list still know the real ladder size.
+     */
+    private int totalEntries;
+}
+```
+
+- [ ] **Step 4: Implement the bound in the application service**
+
+In `league/application/LeagueService.java`, add the imports `com.muddl.riot.lol.league.domain.LeagueItem` and `java.util.Comparator`, then replace `getApexLeague` and add the helper:
+
+```java
+    /** Default number of apex entries returned when the caller does not specify a count. */
+    private static final int DEFAULT_APEX_ENTRIES = 10;
+
+    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier, String queue, Integer count) {
+        log.info("Fetching {} apex league for queue {} on platform: {}", tier, queue, platform);
+        int limit = (count == null || count <= 0) ? DEFAULT_APEX_ENTRIES : count;
+        return boundEntries(leaguePort.getApexLeague(platform, tier, queue), limit);
+    }
+
+    /**
+     * Returns a copy of {@code league} holding only the top {@code limit} entries by league points,
+     * with {@code totalEntries} stamped to the pre-truncation size.
+     *
+     * <p>Riot's League-V4 apex endpoint has no server-side count parameter (unlike
+     * Champion-Mastery-V4, where the bound is pushed down to the port), so the bound is applied
+     * here in the application layer. Riot does not guarantee entry order, so entries are sorted
+     * before slicing — otherwise "top N" is meaningless and a discovered subject would change
+     * between runs. See ADR-0016.
+     */
+    private static LeagueList boundEntries(LeagueList league, int limit) {
+        if (league == null) {
+            return null;
+        }
+        List<LeagueItem> entries = league.getEntries();
+        if (entries == null) {
+            return league.toBuilder().entries(List.of()).totalEntries(0).build();
+        }
+        return league.toBuilder()
+                .entries(entries.stream()
+                        .sorted(Comparator.comparingInt(LeagueItem::getLeaguePoints).reversed())
+                        .limit(limit)
+                        .toList())
+                .totalEntries(entries.size())
+                .build();
+    }
+```
+
+- [ ] **Step 5: Run the service tests to verify they pass**
+
+Run: `./gradlew :lol-mcp-server:test --tests '*league.application.LeagueServiceTest'`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 6: Expose the parameter on the MCP tool**
+
+In `league/adapter/in/mcp/LeagueTool.java`, replace the `getApexLeague` method:
+
+```java
+    @McpTool(
+            name = "lol_league_apex_by_tier",
+            description =
+                    "Get a League of Legends apex league (CHALLENGER, GRANDMASTER, or MASTER) for a ranked queue. Returns the top 10 entries by league points unless a larger count is requested.")
+    public LeagueList getApexLeague(
+            @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
+            @McpToolParam(description = "The apex tier: CHALLENGER, GRANDMASTER, or MASTER", required = true)
+                    String tierStr,
+            @McpToolParam(
+                            description = "The ranked queue, e.g. RANKED_SOLO_5x5 (default) or RANKED_FLEX_SR",
+                            required = false)
+                    String queueStr,
+            @McpToolParam(
+                            description = "Optional: return only the top N entries by league points; defaults to 10",
+                            required = false)
+                    Integer count) {
+        RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
+        ApexTier tier = ApexTier.valueOf(tierStr.toUpperCase());
+        String queue = (queueStr == null || queueStr.isBlank()) ? DEFAULT_QUEUE : queueStr;
+        log.info("MCP Tool - Getting {} apex league for queue {} on platform: {}", tier, queue, platform);
+        return leagueService.getApexLeague(platform, tier, queue, count);
+    }
+```
+
+- [ ] **Step 7: Update the tool tests for the new arity**
+
+In `LeagueToolTest.java`, replace the three apex tests. The tool mocks the service, so `isSameAs` still holds here — only the arity changes, plus one new test proving `count` is passed straight through.
+
+```java
+    @Test
+    void getApexLeague_defaultsQueue_whenNull() {
+        LeagueList league = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null))
+                .thenReturn(league);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null, null)).isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
+    }
+
+    @Test
+    void getApexLeague_honoursExplicitQueue() {
+        LeagueList league = LeagueList.builder().tier("MASTER").build();
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR", null))
+                .thenReturn(league);
+
+        assertThat(leagueTool.getApexLeague("NA1", "master", "RANKED_FLEX_SR", null))
+                .isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR", null);
+    }
+
+    @Test
+    void getApexLeague_passesCountThrough() {
+        LeagueList league = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3))
+                .thenReturn(league);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null, 3)).isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3);
+    }
+
+    @Test
+    void getApexLeague_invalidTier_throws() {
+        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "DIAMOND", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No enum constant");
+    }
+```
+
+- [ ] **Step 8: Format, then run the full LoL module build**
+
+Run: `./gradlew spotlessApply && ./gradlew :lol-mcp-server:build`
+Expected: BUILD SUCCESSFUL. The WireMock test `RiotLeagueAdapterTest` must pass **unchanged** — the adapter still fetches full payloads. If it needed editing, truncation leaked out of the application layer; stop and fix the design.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lol-mcp-server/src/main/java/com/muddl/riot/lol/league lol-mcp-server/src/test/java/com/muddl/riot/lol/league
+git commit -m "feat(lol-league)!: cap lol_league_apex_by_tier at top 10 entries by default
+
+Adds an optional count param and stamps totalEntries with the
+pre-truncation size. Truncation lives in LeagueService because Riot's
+League-V4 apex endpoint has no server-side count parameter."
+```
+
+---
+
+## Task 2: Bound the TFT apex league
+
+**Files:**
+- Modify: `tft-mcp-server/src/main/java/com/muddl/riot/tft/league/domain/LeagueList.java`
+- Modify: `tft-mcp-server/src/main/java/com/muddl/riot/tft/league/application/LeagueService.java`
+- Modify: `tft-mcp-server/src/main/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueTool.java`
+- Test: `tft-mcp-server/src/test/java/com/muddl/riot/tft/league/application/LeagueServiceTest.java`
+- Test: `tft-mcp-server/src/test/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueToolTest.java`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (separate module, separate package root — the two `LeagueList` types are unrelated classes).
+- Produces:
+  - `LeagueList.getTotalEntries()` returns `int`.
+  - `LeagueService.getApexLeague(RiotApiPlatformUri platform, ApexTier tier, Integer count)` returns `LeagueList`.
+  - `LeagueService.getLeagueById(RiotApiPlatformUri platform, String leagueId)` — **signature unchanged**, but now returns a copy with `totalEntries` stamped.
+  - `LeagueTool.getApexLeague(String platformStr, String tierStr, Integer count)` returns `LeagueList`.
+
+**Background for the implementer:** Two traps here, both different from Task 1.
+
+1. TFT's `LeagueList` is shared by `getApexLeague` and `getLeagueById`. Per the spec, `tft_league_by_id` is **out of scope for truncation** — it must stamp `totalEntries` but neither slice nor reorder its entries. Do not route it through the apex helper.
+2. **TFT's `LeagueItem.getLeaguePoints()` returns a boxed `Integer`, not the primitive `int` that LoL's returns.** `Comparator.comparingInt(LeagueItem::getLeaguePoints)` unboxes and throws `NullPointerException` whenever Riot omits the field — passing on hand-built fixtures and failing on live data. The comparator must be null-safe. Do not copy Task 1's helper verbatim.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tft-mcp-server/.../league/application/LeagueServiceTest.java`, replace `getApexLeague_delegatesToPort` and `getLeagueById_delegatesToPort` (both assert `isSameAs`, which no longer holds) and add the new cases. Add imports `com.muddl.riot.tft.league.domain.LeagueItem`, `java.util.ArrayList`, and `java.util.stream.IntStream` (`java.util.List` is already imported).
+
+```java
+    private static LeagueList ladderOf(int size) {
+        return LeagueList.builder()
+                .tier("CHALLENGER")
+                .entries(IntStream.range(0, size)
+                        .mapToObj(i -> LeagueItem.builder()
+                                .puuid("puuid-" + i)
+                                .leaguePoints(i)
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Test
+    void getApexLeague_capsAtTen_whenCountIsNull() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        LeagueList result = service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, null);
+
+        assertThat(result.getEntries()).hasSize(10);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+    }
+
+    @Test
+    void getApexLeague_sortsByLeaguePointsDescending() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 3).getEntries())
+                .extracting(LeagueItem::getLeaguePoints)
+                .containsExactly(299, 298, 297);
+    }
+
+    @Test
+    void getApexLeague_honoursExplicitCount() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 50).getEntries())
+                .hasSize(50);
+    }
+
+    @Test
+    void getApexLeague_zeroOrNegativeCount_clampsToDefault() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 0).getEntries())
+                .hasSize(10);
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, -1).getEntries())
+                .hasSize(10);
+    }
+
+    @Test
+    void getApexLeague_nullLeaguePoints_sortLastWithoutThrowing() {
+        // TFT's LeagueItem.leaguePoints is a boxed Integer and Riot may omit it —
+        // a comparingInt comparator would NPE here.
+        List<LeagueItem> mixed = new ArrayList<>();
+        mixed.add(LeagueItem.builder().puuid("no-lp").leaguePoints(null).build());
+        mixed.add(LeagueItem.builder().puuid("low").leaguePoints(100).build());
+        mixed.add(LeagueItem.builder().puuid("high").leaguePoints(900).build());
+        port.putApex(
+                ApexTier.CHALLENGER,
+                LeagueList.builder().tier("CHALLENGER").entries(mixed).build());
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, null).getEntries())
+                .extracting(LeagueItem::getPuuid)
+                .containsExactly("high", "low", "no-lp");
+    }
+
+    @Test
+    void getApexLeague_nullLeague_returnsNull() {
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.MASTER, null)).isNull();
+    }
+
+    @Test
+    void getLeagueById_stampsTotal_withoutTruncatingOrReordering() {
+        port.putLeague("league-uuid", ladderOf(300));
+
+        LeagueList result = service.getLeagueById(PLATFORM, "league-uuid");
+
+        assertThat(result.getEntries()).hasSize(300);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+        // Original ascending order is preserved — league-by-id is out of scope for the bound.
+        assertThat(result.getEntries().get(0).getLeaguePoints()).isZero();
+    }
+
+    @Test
+    void getLeagueById_nullLeague_returnsNull() {
+        assertThat(service.getLeagueById(PLATFORM, "missing")).isNull();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :tft-mcp-server:test --tests '*league.application.LeagueServiceTest'`
+Expected: FAIL — compilation error, `getApexLeague` cannot be applied to 3 arguments, `getTotalEntries()` does not exist.
+
+- [ ] **Step 3: Add `totalEntries` and `toBuilder` to the domain type**
+
+In `tft-mcp-server/.../league/domain/LeagueList.java`:
+
+```java
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeagueList {
+    private String leagueId;
+    private String tier;
+    private String name;
+    private String queue;
+    private List<LeagueItem> entries;
+
+    /**
+     * Total entries in the league before any {@code count} bound was applied. Lets a caller that
+     * received a capped {@link #entries} list still know the real ladder size.
+     */
+    private int totalEntries;
+}
+```
+
+- [ ] **Step 4: Implement the bound in the application service**
+
+In `tft-mcp-server/.../league/application/LeagueService.java`, add imports `com.muddl.riot.tft.league.domain.LeagueItem` and `java.util.Comparator`, then replace `getApexLeague` and `getLeagueById` and add the helper:
+
+```java
+    /** Default number of apex entries returned when the caller does not specify a count. */
+    private static final int DEFAULT_APEX_ENTRIES = 10;
+
+    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier, Integer count) {
+        log.info("Fetching TFT {} apex league on platform: {}", tier, platform);
+        int limit = (count == null || count <= 0) ? DEFAULT_APEX_ENTRIES : count;
+        return boundEntries(leaguePort.getApexLeague(platform, tier), limit);
+    }
+
+    public LeagueList getLeagueById(RiotApiPlatformUri platform, String leagueId) {
+        log.info("Fetching TFT league by id on platform: {}", platform);
+        LeagueList league = leaguePort.getLeagueById(platform, leagueId);
+        if (league == null) {
+            return null;
+        }
+        // Stamp the total for consistency with the apex response, but neither slice nor reorder:
+        // tft_league_by_id is deliberately out of scope for the bound (ADR-0016).
+        return league.toBuilder()
+                .totalEntries(league.getEntries() == null ? 0 : league.getEntries().size())
+                .build();
+    }
+
+    /**
+     * Returns a copy of {@code league} holding only the top {@code limit} entries by league points,
+     * with {@code totalEntries} stamped to the pre-truncation size. Riot's TFT-League-V1 apex
+     * endpoint has no server-side count parameter, so the bound is applied here in the application
+     * layer; entries are sorted first because Riot does not guarantee order. See ADR-0016.
+     *
+     * <p>Unlike the LoL server's equivalent, {@code leaguePoints} here is a boxed {@link Integer}
+     * and Riot may omit it, so the comparator is null-safe (nulls sort last) rather than a
+     * {@code comparingInt}, which would unbox and throw.
+     */
+    private static LeagueList boundEntries(LeagueList league, int limit) {
+        if (league == null) {
+            return null;
+        }
+        List<LeagueItem> entries = league.getEntries();
+        if (entries == null) {
+            return league.toBuilder().entries(List.of()).totalEntries(0).build();
+        }
+        return league.toBuilder()
+                .entries(entries.stream()
+                        .sorted(Comparator.comparing(
+                                LeagueItem::getLeaguePoints,
+                                Comparator.nullsLast(Comparator.reverseOrder())))
+                        .limit(limit)
+                        .toList())
+                .totalEntries(entries.size())
+                .build();
+    }
+```
+
+- [ ] **Step 5: Run the service tests to verify they pass**
+
+Run: `./gradlew :tft-mcp-server:test --tests '*league.application.LeagueServiceTest'`
+Expected: PASS.
+
+- [ ] **Step 6: Expose the parameter on the MCP tool**
+
+In `tft-mcp-server/.../league/adapter/in/mcp/LeagueTool.java`, replace `getApexLeague`:
+
+```java
+    @McpTool(
+            name = "tft_league_apex_by_tier",
+            description =
+                    "Get a Teamfight Tactics apex league: CHALLENGER, GRANDMASTER, or MASTER. Returns the top 10 entries by league points unless a larger count is requested.")
+    public LeagueList getApexLeague(
+            @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
+            @McpToolParam(description = "The apex tier: CHALLENGER, GRANDMASTER, or MASTER", required = true)
+                    String tierStr,
+            @McpToolParam(
+                            description = "Optional: return only the top N entries by league points; defaults to 10",
+                            required = false)
+                    Integer count) {
+        RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
+        ApexTier tier = ApexTier.valueOf(tierStr.toUpperCase());
+        log.info("MCP Tool - Getting TFT {} apex league on platform: {}", tier, platform);
+        return leagueService.getApexLeague(platform, tier, count);
+    }
+```
+
+- [ ] **Step 7: Update the tool tests for the new arity**
+
+In `tft-mcp-server/.../league/adapter/in/mcp/LeagueToolTest.java`, replace the four apex tests. Leave the `getLeagueById` tests alone — that service signature is unchanged.
+
+```java
+    @Test
+    void getApexLeague_passesPlatformAndTierThrough() {
+        LeagueList list = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, null))
+                .thenReturn(list);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, null);
+    }
+
+    @Test
+    void getApexLeague_normalizesCaseForPlatformAndTier() {
+        LeagueList list = LeagueList.builder().tier("MASTER").build();
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER, null))
+                .thenReturn(list);
+
+        assertThat(leagueTool.getApexLeague("na1", "master", null)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER, null);
+    }
+
+    @Test
+    void getApexLeague_passesCountThrough() {
+        LeagueList list = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, 3))
+                .thenReturn(list);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", 3)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, 3);
+    }
+
+    @Test
+    void getApexLeague_invalidPlatform_throws() {
+        assertThatThrownBy(() -> leagueTool.getApexLeague("INVALID", "CHALLENGER", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No enum constant");
+    }
+
+    @Test
+    void getApexLeague_invalidTier_throws() {
+        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "BRONZE", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No enum constant");
+    }
+```
+
+- [ ] **Step 8: Format, then run the full TFT module build**
+
+Run: `./gradlew spotlessApply && ./gradlew :tft-mcp-server:build`
+Expected: BUILD SUCCESSFUL. `RiotTftLeagueAdapterTest` must pass unchanged.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tft-mcp-server/src/main/java/com/muddl/riot/tft/league tft-mcp-server/src/test/java/com/muddl/riot/tft/league
+git commit -m "feat(tft-league)!: cap tft_league_apex_by_tier at top 10 entries by default
+
+Mirrors the LoL change. tft_league_by_id stamps totalEntries but is
+deliberately left unbounded and unsorted."
+```
+
+---
+
+## Task 3: Bound the LoL challenges payload
+
+**Files:**
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengesPlayerData.java`
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/application/ChallengesService.java`
+- Modify: `lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesTool.java`
+- Test: `lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/application/ChallengesServiceTest.java`
+- Test: `lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesToolTest.java`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1–2.
+- Produces:
+  - `ChallengesPlayerData.getTotalChallenges()` returns `int`.
+  - `ChallengesService.getChallengesByPlayer(RiotApiPlatformUri platform, String player, Integer count)` returns `ChallengesPlayerData`.
+  - `ChallengesTool.getChallengesByPlayer(String platformStr, String player, Integer count)` returns `ChallengesPlayerData`.
+
+**Background for the implementer:** `ChallengeProgress.getPercentile()` returns a **boxed `Double` that Riot leaves null** on challenges a player has not progressed on. A naive `Comparator.comparing(ChallengeProgress::getPercentile)` throws `NullPointerException` on live data while passing on hand-built fixtures — the comparator must be null-safe. Lower percentile means a rarer achievement, so the sort is **ascending** with nulls last.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing `getChallengesByPlayer_resolvesPlayer_thenReturnsData` test (it asserts `isSameAs`, no longer true) and add the new cases in `ChallengesServiceTest.java`. Add imports `com.muddl.riot.lol.challenges.domain.ChallengeProgress`, `java.util.ArrayList`, `java.util.List`, `java.util.stream.IntStream`.
+
+```java
+    private static ChallengesPlayerData dataWith(List<ChallengeProgress> challenges) {
+        return ChallengesPlayerData.builder()
+                .totalPoints(ChallengePoints.builder().level("DIAMOND").build())
+                .challenges(challenges)
+                .build();
+    }
+
+    private static List<ChallengeProgress> progressOf(int size) {
+        // percentile descending with index, so the *last* entries are the best —
+        // a service that slices without sorting will fail these tests.
+        return IntStream.range(0, size)
+                .mapToObj(i -> ChallengeProgress.builder()
+                        .challengeId((long) i)
+                        .percentile(1.0 - (i / (double) size))
+                        .build())
+                .toList();
+    }
+
+    @Test
+    void getChallengesByPlayer_capsAtTen_andKeepsSummary() {
+        when(resolver.resolvePuuid("Faker#KR1")).thenReturn("faker-puuid");
+        port.put("faker-puuid", dataWith(progressOf(500)));
+
+        ChallengesPlayerData result = service.getChallengesByPlayer(PLATFORM, "Faker#KR1", null);
+
+        assertThat(result.getChallenges()).hasSize(10);
+        assertThat(result.getTotalChallenges()).isEqualTo(500);
+        assertThat(result.getTotalPoints().getLevel()).isEqualTo("DIAMOND");
+    }
+
+    @Test
+    void getChallengesByPlayer_sortsByPercentileAscending() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 3).getChallenges())
+                .extracting(ChallengeProgress::getChallengeId)
+                .containsExactly(499L, 498L, 497L);
+    }
+
+    @Test
+    void getChallengesByPlayer_honoursExplicitCount() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 42).getChallenges())
+                .hasSize(42);
+    }
+
+    @Test
+    void getChallengesByPlayer_zeroOrNegativeCount_clampsToDefault() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 0).getChallenges())
+                .hasSize(10);
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", -9).getChallenges())
+                .hasSize(10);
+    }
+
+    @Test
+    void getChallengesByPlayer_nullPercentiles_sortLastWithoutThrowing() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        List<ChallengeProgress> mixed = new ArrayList<>();
+        mixed.add(ChallengeProgress.builder().challengeId(1L).percentile(null).build());
+        mixed.add(ChallengeProgress.builder().challengeId(2L).percentile(0.5).build());
+        mixed.add(ChallengeProgress.builder().challengeId(3L).percentile(0.01).build());
+        port.put("p", dataWith(mixed));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", null).getChallenges())
+                .extracting(ChallengeProgress::getChallengeId)
+                .containsExactly(3L, 2L, 1L);
+    }
+
+    @Test
+    void getChallengesByPlayer_nullChallenges_yieldsEmptyListAndZeroTotal() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", ChallengesPlayerData.builder().build());
+
+        ChallengesPlayerData result = service.getChallengesByPlayer(PLATFORM, "p", null);
+
+        assertThat(result.getChallenges()).isEmpty();
+        assertThat(result.getTotalChallenges()).isZero();
+    }
+
+    @Test
+    void getChallengesByPlayer_nullData_returnsNull() {
+        when(resolver.resolvePuuid("unknown")).thenReturn("unknown");
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "unknown", null)).isNull();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :lol-mcp-server:test --tests '*challenges.application.ChallengesServiceTest'`
+Expected: FAIL — compilation error, `getChallengesByPlayer` cannot be applied to 3 arguments, `getTotalChallenges()` does not exist.
+
+- [ ] **Step 3: Add `totalChallenges` and `toBuilder` to the domain type**
+
+In `challenges/domain/ChallengesPlayerData.java`:
+
+```java
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChallengesPlayerData {
+    private ChallengePoints totalPoints;
+    private Map<String, ChallengePoints> categoryPoints;
+    private List<ChallengeProgress> challenges;
+
+    /**
+     * Total challenges returned by Riot before any {@code count} bound was applied. Lets a caller
+     * that received a capped {@link #challenges} list know how many exist.
+     */
+    private int totalChallenges;
+}
+```
+
+- [ ] **Step 4: Implement the bound in the application service**
+
+In `challenges/application/ChallengesService.java`, add imports `com.muddl.riot.lol.challenges.domain.ChallengeProgress`, `java.util.Comparator`, `java.util.List`, then replace the method and add the helper:
+
+```java
+    /** Default number of individual challenges returned when the caller does not specify a count. */
+    private static final int DEFAULT_CHALLENGES = 10;
+
+    public ChallengesPlayerData getChallengesByPlayer(
+            RiotApiPlatformUri platform, String player, Integer count) {
+        String puuid = identityResolver.resolvePuuid(player);
+        log.info("Fetching challenge data on platform: {}", platform);
+        int limit = (count == null || count <= 0) ? DEFAULT_CHALLENGES : count;
+        return boundChallenges(challengesPort.getPlayerDataByPuuid(platform, puuid), limit);
+    }
+
+    /**
+     * Returns a copy of {@code data} holding only the {@code limit} strongest challenges, with
+     * {@code totalChallenges} stamped to the pre-truncation size. {@code totalPoints} and
+     * {@code categoryPoints} are always returned in full — they are the summary and cost almost
+     * nothing, while Riot's per-challenge array runs to ~500 rows and is ~99% of the payload.
+     *
+     * <p>Sorted by percentile <em>ascending</em>, because a lower percentile is a rarer
+     * achievement. The comparator must tolerate nulls: Riot omits {@code percentile} on challenges
+     * a player has not progressed on. See ADR-0016.
+     */
+    private static ChallengesPlayerData boundChallenges(ChallengesPlayerData data, int limit) {
+        if (data == null) {
+            return null;
+        }
+        List<ChallengeProgress> challenges = data.getChallenges();
+        if (challenges == null) {
+            return data.toBuilder().challenges(List.of()).totalChallenges(0).build();
+        }
+        return data.toBuilder()
+                .challenges(challenges.stream()
+                        .sorted(Comparator.comparing(
+                                ChallengeProgress::getPercentile,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
+                        .limit(limit)
+                        .toList())
+                .totalChallenges(challenges.size())
+                .build();
+    }
+```
+
+- [ ] **Step 5: Run the service tests to verify they pass**
+
+Run: `./gradlew :lol-mcp-server:test --tests '*challenges.application.ChallengesServiceTest'`
+Expected: PASS.
+
+- [ ] **Step 6: Expose the parameter on the MCP tool**
+
+In `challenges/adapter/in/mcp/ChallengesTool.java`, replace the method:
+
+```java
+    @McpTool(
+            name = "lol_challenges_by_player",
+            description =
+                    "Get a League of Legends player's challenge standing: total and per-category points, and per-challenge progress. Per-challenge progress returns the 10 strongest challenges unless a larger count is requested; totals and category points are always complete.")
+    public ChallengesPlayerData getChallengesByPlayer(
+            @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
+            @McpToolParam(description = "The player as a Riot ID (GameName#TAG) or a raw PUUID", required = true)
+                    String player,
+            @McpToolParam(
+                            description =
+                                    "Optional: return only the top N individual challenges by percentile; defaults to 10",
+                            required = false)
+                    Integer count) {
+        RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
+        log.info("MCP Tool - Getting challenge data for a player on platform: {}", platform);
+        return challengesService.getChallengesByPlayer(platform, player, count);
+    }
+```
+
+- [ ] **Step 7: Update the tool tests for the new arity**
+
+Replace both tests in `ChallengesToolTest.java`:
+
+```java
+    @Test
+    void getChallengesByPlayer_passesPlatformAndPlayerThrough() {
+        ChallengesPlayerData data = ChallengesPlayerData.builder().build();
+        when(mockService.getChallengesByPlayer(PLATFORM, "Faker#KR1", null)).thenReturn(data);
+
+        assertThat(tool.getChallengesByPlayer("NA1", "Faker#KR1", null)).isSameAs(data);
+        verify(mockService).getChallengesByPlayer(PLATFORM, "Faker#KR1", null);
+    }
+
+    @Test
+    void getChallengesByPlayer_passesCountThrough() {
+        ChallengesPlayerData data = ChallengesPlayerData.builder().build();
+        when(mockService.getChallengesByPlayer(PLATFORM, "Faker#KR1", 5)).thenReturn(data);
+
+        assertThat(tool.getChallengesByPlayer("NA1", "Faker#KR1", 5)).isSameAs(data);
+        verify(mockService).getChallengesByPlayer(PLATFORM, "Faker#KR1", 5);
+    }
+
+    @Test
+    void getChallengesByPlayer_invalidPlatform_throws() {
+        assertThatThrownBy(() -> tool.getChallengesByPlayer("INVALID", "Faker#KR1", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No enum constant");
+    }
+```
+
+- [ ] **Step 8: Format and run the whole build**
+
+Run: `./gradlew spotlessApply && ./gradlew build`
+Expected: BUILD SUCCESSFUL across all modules — ArchUnit, JaCoCo, and Spotless included. This is the first point where the full gate runs after all three Java changes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges
+git commit -m "feat(lol-challenges)!: cap lol_challenges_by_player per-challenge list at 10
+
+Totals and category points always return in full; the ~500-row
+per-challenge array is bounded and sorted by percentile ascending with
+a null-safe comparator (Riot omits percentile on unprogressed challenges)."
+```
+
+---
+
+## Task 4: Fix the eval rubrics
+
+**Files:**
+- Modify: `eval/tests/test_championmastery.py`
+- Modify: `eval/tests/test_league.py:7-32` (the `test_apex_challenger` task)
+
+**Interfaces:**
+- Consumes: `LeagueList.totalEntries` from Task 1 (serialized as `totalEntries` in the tool's JSON response).
+- Produces: nothing consumed by later tasks.
+
+**Background for the implementer:** `test_champion_mastery_for_discovered_player` failed on `stdio` and passed on `sse` in the baseline run. The cause is a **prompt/rubric mismatch, not flakiness**: the prompt asks for *"the top champion and its mastery point value"* (singular), while the rubric grades *"at most 3 champion mastery entries"*. The agent obeyed the prompt, reported one champion, and the judge marked it down. The `count` assertion belongs in a deterministic structural check.
+
+`Expect.tools.called_with(tool_name, arguments)` does **subset** argument matching — it checks `all(call.arguments.get(k) == v for k, v in expected.items())` — so only `count` needs to be named. It costs zero judge tokens.
+
+- [ ] **Step 1: Rewrite the champion mastery task**
+
+Replace the whole body of `eval/tests/test_championmastery.py`:
+
+```python
+"""Champion mastery live eval. The subject is discovered from the CHALLENGER
+ladder, exercising the player-keyed path plus the optional top-N count param.
+
+The count param is asserted structurally, not through the judge: the prompt asks
+for a single champion, so a rubric that graded "reports 3 entries" would penalise
+the agent for obeying the prompt. See gotchas.md."""
+
+from mcp_eval import task, Expect
+
+
+@task("Champion mastery resolves for a discovered player")
+async def test_champion_mastery_for_discovered_player(agent, session):
+    response = await agent.generate_str(
+        "Get the CHALLENGER apex league for RANKED_SOLO_5x5 on NA1, pick any "
+        "one player, then get that player's champion mastery on NA1, limited "
+        "to their top 3 champions by mastery points. Report the top champion "
+        "and its mastery point value."
+    )
+    await session.assert_that(
+        Expect.tools.was_called("lol_champion_mastery_by_player"),
+        name="champion_mastery_called",
+    )
+    # Structural, not judged: proves the top-N count param reached the tool.
+    await session.assert_that(
+        Expect.tools.called_with("lol_champion_mastery_by_player", {"count": 3}),
+        name="champion_mastery_count_passed",
+    )
+    await session.assert_that(
+        Expect.judge.llm(
+            rubric=(
+                "The answer names the top champion by mastery points and gives "
+                "its mastery point value, which must be non-negative. If the "
+                "player has no mastery data, it clearly says so instead. It "
+                "must not report a tool error. Reporting only the single top "
+                "champion is correct and expected — do not require additional "
+                "champions to be listed."
+            ),
+            min_score=0.7,
+        ),
+        response=response,
+        name="champion_mastery_reported",
+    )
+```
+
+- [ ] **Step 2: Retarget the apex rubric at `totalEntries`**
+
+In `eval/tests/test_league.py`, replace the `test_apex_challenger` task. Without this the task silently starts asserting on a 10-entry truncated view instead of the real ladder.
+
+```python
+@task("Apex league returns a populated CHALLENGER ladder")
+async def test_apex_challenger(agent, session):
+    response = await agent.generate_str(
+        "Get the CHALLENGER apex league for the RANKED_SOLO_5x5 queue on NA1. "
+        "The tool caps the entries it returns, so report the total number of "
+        "players in the league (the totalEntries field), and name one player "
+        "from the entries you received."
+    )
+    await session.assert_that(
+        Expect.tools.was_called("lol_league_apex_by_tier"),
+        name="apex_tool_called",
+    )
+    await session.assert_that(
+        Expect.judge.llm(
+            rubric=(
+                "The answer reports a CHALLENGER league whose total size is well "
+                "above the number of entries actually returned — a real ladder has "
+                "on the order of hundreds of players, so a reported total of only "
+                "about ten means the truncated list was mistaken for the whole "
+                "league and must fail. It also identifies at least one entry. A "
+                "PUUID, summoner id, or LP/rank is sufficient identification — Riot "
+                "no longer exposes human-readable summoner names in league entries, "
+                "so do not require a display name. It does not report an error or "
+                "an empty league."
+            ),
+            min_score=0.7,
+        ),
+        response=response,
+        name="apex_reports_true_ladder_size",
+    )
+```
+
+- [ ] **Step 3: Verify the files parse**
+
+Run: `cd eval && uv run python -c "import ast,pathlib; [ast.parse(p.read_text(encoding='utf-8')) for p in pathlib.Path('tests').glob('test_*.py')]; print('OK')"`
+Expected: `OK`
+
+These tasks only truly execute against live servers with real keys, which happens in Task 8. This step catches syntax errors early without spending tokens.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add eval/tests/test_championmastery.py eval/tests/test_league.py
+git commit -m "fix(eval): assert mastery count structurally; retarget apex rubric at totalEntries
+
+The mastery rubric graded 'reports at most 3 entries' while the prompt
+asked for one champion, so the judge penalised correct behaviour. Moves
+that assertion to Expect.tools.called_with and narrows the rubric.
+
+The apex rubric would otherwise silently assert on the newly truncated
+entry list rather than the real ladder size."
+```
+
+---
+
+## Task 5: Transport-scoped eval coverage
+
+**Files:**
+- Create: `eval/smoke.txt`
+- Modify: `.github/workflows/live-eval.yml` (the `Run live evals` and `Summarize outcome` steps)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `eval/smoke.txt` — newline-delimited `file.py::func` specs, `#` comments and blank lines ignored. Task 7 documents it.
+
+**Background for the implementer:** `mcp-eval run` accepts multiple positional path specs including pytest-style `file.py::func`, but has **no `-k`, no markers, and no tag system** — verified against `mcp_eval/runner.py` in the pinned 0.1.10 release. The subset therefore has to be explicit paths. GitHub Actions `run:` blocks on `ubuntu-latest` use bash, so `mapfile` is available.
+
+- [ ] **Step 1: Create the smoke set**
+
+Create `eval/smoke.txt`:
+
+```
+# Transport smoke set — run on the sse leg instead of the full suite.
+#
+# These four tasks prove the *transport wiring*, not the tool logic: the stdio
+# leg runs the full suite against the same jars, so anything below the transport
+# layer is already covered there. Keep this list small — every entry is paid for
+# on every dispatch. See ADR-0017.
+#
+# One "file.py::function" spec per line; blank lines and # comments are ignored.
+
+# sse handshake and tool discovery
+tests/test_handshake.py::test_lists_tools
+
+# a tool round-trip on each server (the two run on different ports)
+tests/test_status.py::test_status_platform
+tests/test_tft_status.py::test_tft_status_platform
+
+# errors must surface through the transport — Spring AI's MCP layer only reports
+# a generic "Error invoking method" over sse, so this is the leg's weak spot
+tests/test_canaries.py::test_invalid_platform
+```
+
+- [ ] **Step 2: Verify every spec in the smoke set resolves**
+
+Run:
+```bash
+cd eval && grep -vE '^\s*(#|$)' smoke.txt | while IFS= read -r spec; do
+  f="${spec%%::*}"; fn="${spec##*::}"
+  test -f "$f" || { echo "MISSING FILE: $f"; exit 1; }
+  grep -q "def ${fn}(" "$f" || { echo "MISSING FUNC: $spec"; exit 1; }
+  echo "ok: $spec"
+done
+```
+Expected: four `ok:` lines and no `MISSING` output.
+
+- [ ] **Step 3: Scope the workflow's run step by transport**
+
+In `.github/workflows/live-eval.yml`, replace the `run:` body of the `Run live evals` step:
+
+```yaml
+        run: |
+          # mcp-eval does NOT expand ${VAR} placeholders in the config's
+          # command/args/url/env fields, so we expand them here before it reads
+          # the file. Restricted to our vars so nothing else is touched.
+          envsubst '${LOL_MCP_JAR} ${TFT_MCP_JAR} ${LOL_DEV_API_KEY} ${TFT_DEV_API_KEY} ${LOL_MCP_SSE_URL} ${TFT_MCP_SSE_URL}' \
+            < "mcpeval.${{ matrix.transport }}.yaml" > mcpeval.yaml
+          # stdio carries the full suite; sse runs only the transport smoke set,
+          # since both legs otherwise pay for an identical result (ADR-0017).
+          # mcp-eval has no -k/marker selection, so the subset is explicit paths.
+          if [ "${{ matrix.transport }}" = "sse" ]; then
+            mapfile -t SPECS < <(grep -vE '^\s*(#|$)' smoke.txt)
+            echo "EVAL_SCOPE=transport smoke set (${#SPECS[@]} tasks)" >> "$GITHUB_ENV"
+          else
+            SPECS=(tests/)
+            echo "EVAL_SCOPE=full suite" >> "$GITHUB_ENV"
+          fi
+          set +e
+          uv run mcp-eval run "${SPECS[@]}" -v \
+            --json "test-reports/${{ matrix.transport }}.json" \
+            --html "test-reports/${{ matrix.transport }}.html" \
+            --markdown "test-reports/${{ matrix.transport }}.md"
+          echo "EVAL_EXIT=$?" >> "$GITHUB_ENV"
+          set -e
+```
+
+- [ ] **Step 4: Make the job summary scope-aware**
+
+Still in `live-eval.yml`, replace the `run:` body of the `Summarize outcome` step. Without this a green `sse` leg reads as full coverage.
+
+```yaml
+        run: |
+          {
+            echo "## Live eval — ${{ matrix.transport }} (${EVAL_SCOPE:-unknown scope})"
+            if [ "${EVAL_EXIT:-1}" = "0" ]; then
+              echo "✅ All live evals passed."
+            else
+              echo "❌ Live evals reported failures (exit ${EVAL_EXIT})."
+              echo ""
+              echo "Triage: a **CANARY** failure means Riot's live behavior may have changed — investigate the adapter's assumption before editing the test. A non-canary failure is a regression. Rate-limit / network / Riot 5xx errors are infra flakes — re-run the workflow."
+            fi
+            if [ "${{ matrix.transport }}" = "sse" ]; then
+              echo ""
+              echo "> This leg runs the **transport smoke set** (\`eval/smoke.txt\`), not the full suite. Tool-logic coverage comes from the stdio leg."
+            fi
+            echo ""
+            echo "See the uploaded \`mcpeval-reports-${{ matrix.transport }}\` artifact (Markdown/HTML/JSON) for per-test detail."
+          } >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] **Step 5: Verify the workflow is valid YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/live-eval.yml',encoding='utf-8')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add eval/smoke.txt .github/workflows/live-eval.yml
+git commit -m "ci(eval): run the full suite on stdio, a transport smoke set on sse
+
+Both legs previously ran identical tasks for an identical result. The
+sse leg now runs four tasks covering handshake, a round-trip per server,
+and error propagation. The job summary names the scope so a green sse
+leg is not mistaken for full coverage."
+```
+
+---
+
+## Task 6: Cost report script
+
+**Files:**
+- Create: `eval/tools/report-cost.py`
+
+**Interfaces:**
+- Consumes: an mcp-eval JSON report (`eval/test-reports/<transport>.json`), whose shape is `{"decorator_tests": [{"test_name": str, "passed": bool, "metrics": {"llm_metrics": {"input_tokens": int, "output_tokens": int}, "tool_calls": [{"name": str, "result": {...}}], "iteration_count": int}}, ...]}`.
+- Produces: a CLI used by Task 8 — `uv run python tools/report-cost.py <report.json>`, printing per-test and per-tool tables and a total, exiting 0.
+
+**Background for the implementer:** **Do not use the report's own `cost_estimate` field.** It prices at a ~$0.50/MTok fallback rate, understating Haiku 4.5 by roughly 2×, and it excludes LLM-judge calls entirely. Price from raw token counts at the real rates instead.
+
+- [ ] **Step 1: Write the script**
+
+Create `eval/tools/report-cost.py`:
+
+```python
+#!/usr/bin/env python3
+"""Summarise the token spend of a live-eval run.
+
+Reads an mcp-eval JSON report and prints per-test and per-tool token tables plus
+a priced total.
+
+Deliberately ignores the report's own ``cost_estimate`` field: it prices at a
+~$0.50/MTok fallback rate (understating Claude Haiku 4.5 by roughly 2x) and
+excludes LLM-judge calls entirely. We price from raw token counts instead, so
+the number moves for the same reason the bill does.
+
+Usage:
+    cd eval && uv run python tools/report-cost.py test-reports/stdio.json
+    cd eval && uv run python tools/report-cost.py test-reports/stdio.json test-reports/sse.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Claude Haiku 4.5 list rates, USD per million tokens.
+INPUT_PER_MTOK = 1.00
+OUTPUT_PER_MTOK = 5.00
+
+
+def price(input_tokens: int, output_tokens: int) -> float:
+    """Cost in USD of the given token counts at Haiku 4.5 rates."""
+    return (input_tokens * INPUT_PER_MTOK + output_tokens * OUTPUT_PER_MTOK) / 1_000_000
+
+
+def token_counts(test: dict) -> tuple[int, int]:
+    """Input and output tokens for one test, tolerating both metric layouts."""
+    metrics = test.get("metrics") or {}
+    llm = metrics.get("llm_metrics") or {}
+    return (
+        llm.get("input_tokens", metrics.get("input_tokens", 0)) or 0,
+        llm.get("output_tokens", metrics.get("output_tokens", 0)) or 0,
+    )
+
+
+def report(path: Path) -> tuple[int, int]:
+    """Print the tables for one report file; return its (input, output) totals."""
+    tests = json.loads(path.read_text(encoding="utf-8")).get("decorator_tests", [])
+    if not tests:
+        print(f"{path}: no decorator_tests found", file=sys.stderr)
+        return 0, 0
+
+    rows = []
+    tool_sizes: dict[str, list[int]] = defaultdict(list)
+    total_in = total_out = 0
+
+    for test in tests:
+        tokens_in, tokens_out = token_counts(test)
+        total_in += tokens_in
+        total_out += tokens_out
+        metrics = test.get("metrics") or {}
+        calls = metrics.get("tool_calls") or []
+        rows.append(
+            (
+                price(tokens_in, tokens_out),
+                tokens_in,
+                tokens_out,
+                len(calls),
+                metrics.get("iteration_count"),
+                bool(test.get("passed")),
+                test.get("test_name", "?"),
+            )
+        )
+        for call in calls:
+            # Approximate the emitted result size in tokens. ~4 chars per token is
+            # close enough to rank tools by payload weight.
+            tool_sizes[call.get("name", "?")].append(len(json.dumps(call.get("result", {}))) // 4)
+
+    print(f"\n=== {path.name} ===")
+    print(
+        f"{len(tests)} tasks | in {total_in:,} | out {total_out:,} "
+        f"| ${price(total_in, total_out):.4f} @ Haiku 4.5 rates"
+    )
+
+    print(f"\n{'cost':>9}  {'in':>9}  {'out':>6}  {'calls':>5}  {'iter':>4}  ok  test")
+    for cost, tokens_in, tokens_out, calls, iterations, passed, name in sorted(rows, reverse=True):
+        print(
+            f"${cost:>8.4f}  {tokens_in:>9,}  {tokens_out:>6,}  {calls:>5}  "
+            f"{str(iterations or '-'):>4}  {'y' if passed else 'N':>2}  {name}"
+        )
+
+    if tool_sizes:
+        print(f"\n{'tool':<42} {'n':>3}  {'avg tok':>8}  {'total tok':>10}")
+        for name, sizes in sorted(tool_sizes.items(), key=lambda kv: -sum(kv[1])):
+            print(f"{name:<42} {len(sizes):>3}  {sum(sizes) // len(sizes):>8,}  {sum(sizes):>10,}")
+
+    return total_in, total_out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    grand_in = grand_out = 0
+    reported = 0
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.is_file():
+            print(f"skipping missing file: {path}", file=sys.stderr)
+            continue
+        tokens_in, tokens_out = report(path)
+        grand_in += tokens_in
+        grand_out += tokens_out
+        reported += 1
+
+    if reported > 1:
+        print("\n=== combined ===")
+        print(
+            f"in {grand_in:,} | out {grand_out:,} "
+            f"| ${price(grand_in, grand_out):.4f} @ Haiku 4.5 rates"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+```
+
+- [ ] **Step 2: Verify it runs against the captured baseline**
+
+The baseline artifacts may not be on disk. Fetch them, then run the script:
+
+```bash
+cd eval
+gh run download 30011353019 -R Muddl/riot-api-mcp-server -D /tmp/baseline
+uv run python tools/report-cost.py /tmp/baseline/mcpeval-reports-stdio/eval/test-reports/stdio.json
+```
+
+Expected: a table headed `24 tasks | in 1,250,624 | out 10,246 | $1.3019 @ Haiku 4.5 rates`, with `test_match_detail_for_discovered_match` at the top and `lol_league_apex_by_tier` ranked first in the tool table at ~17,900 average tokens. If the totals do not match those numbers exactly, the script is reading the wrong field — fix it before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add eval/tools/report-cost.py
+git commit -m "feat(eval): add report-cost.py for token/cost aggregation
+
+Prices from raw token counts at real Haiku 4.5 rates. The report's own
+cost_estimate field uses a ~\$0.50/MTok fallback and omits judge calls."
+```
+
+---
+
+## Task 7: Documentation and knowledge persistence
+
+**Files:**
+- Create: `docs/knowledge/decisions/ADR-0016-bounded-list-results.md`
+- Create: `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md`
+- Modify: `docs/knowledge/gotchas.md`
+- Modify: `docs/knowledge/patterns/live-eval-harness.md`
+- Modify: `docs/knowledge/README.md` (the ADR index)
+- Modify: `eval/README.md`
+- Modify: `.claude/skills/add-live-eval/SKILL.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–6.
+- Produces: nothing consumed by later tasks.
+
+**Background for the implementer:** Read `docs/knowledge/README.md` first for the ADR template and index format, and match the heading structure of an existing ADR (e.g. `ADR-0014-non-player-keyed-tools.md`). `ADR-0015` is the highest existing number.
+
+- [ ] **Step 1: Write ADR-0016**
+
+Create `docs/knowledge/decisions/ADR-0016-bounded-list-results.md`, following the existing ADR template. It must record:
+
+- **Context:** `lol_league_apex_by_tier` returned the entire ~300-entry CHALLENGER ladder — ~17,900 tokens per call. Because it lands on turn 1 of a 3–4 iteration agent chain and is re-sent every iteration, it accounted for ~58% of all live-eval input tokens (measured: run `30011353019`, 1,250,624 input tokens per transport). `lol_challenges_by_player` had the same shape: a ~150-token useful head plus a ~500-row array that was ~99% of the payload.
+- **Decision:** an optional `count` param on `lol_league_apex_by_tier`, `tft_league_apex_by_tier`, and `lol_challenges_by_player`, with a **capped default of 10**. Pre-truncation sizes exposed as `totalEntries` / `totalChallenges`.
+- **Why a capped default rather than an opt-in param:** an opt-in leaves the naive call — the one a real agent makes — at 18k tokens, and would have forced every eval prompt to be rewritten. Capping the default fixed the cost with zero eval-prompt churn.
+- **Why the application layer:** Riot's League-V4, TFT-League-V1, and Challenges-V1 endpoints have **no server-side count parameter**, unlike Champion-Mastery-V4, where `ChampionMasteryService` pushes `count` down to the port. Same MCP-level contract, two implementation layers, chosen by whether Riot supports it upstream. Adapters stay dumb mappers and the hexagon rules hold.
+- **Ordering:** Riot does not guarantee entry order, so entries are sorted before slicing (`leaguePoints` descending; challenge `percentile` ascending, nulls last) — otherwise "top N" is meaningless and a discovered eval subject would change between runs.
+- **Consequences:** a behavior change to three published tools; tool names and existing param descriptions are unchanged. `tft_league_rated_ladder_by_queue` and `tft_league_by_id` remain **known-unbounded** — no eval exercises them, so capping them was out of scope; the same remedy applies if they ever matter. `tft_league_by_id` stamps `totalEntries` but neither slices nor reorders.
+
+- [ ] **Step 2: Write ADR-0017**
+
+Create `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md`. It must record:
+
+- **Context:** the `stdio` and `sse` legs ran the identical 24-task suite and produced identical outcomes (within 0.03% on tokens in run `30011353019`), paying twice for one signal. The tool logic under test is the same jars either way.
+- **Decision:** `stdio` runs the full suite; `sse` runs a four-task smoke set listed in `eval/smoke.txt` — handshake/discovery, a round-trip per server, and error propagation.
+- **Mechanism:** `mcp-eval run` takes positional path specs including `file.py::func` but has **no `-k`, markers, or tags** (verified against `mcp_eval/runner.py` in 0.1.10), so the subset must be explicit paths. The list lives next to the tests rather than in CI YAML so it is visible to anyone adding a test.
+- **What the sse leg does not prove:** any tool-logic regression. That coverage comes from `stdio`. The job summary names the scope so a green `sse` leg is never read as full coverage.
+- **Relationship to ADR-0012:** narrows the coverage matrix; the harness's purpose, non-gating status, and credential model are unchanged.
+
+- [ ] **Step 3: Add both gotchas**
+
+Append to `docs/knowledge/gotchas.md`, matching the file's existing entry format:
+
+1. **mcp-eval's `cost_estimate` understates the bill by ~2× and omits judge tokens.** It prices at a ~$0.50/MTok fallback rate; Claude Haiku 4.5 is $1.00/MTok input and $5.00/MTok output. It also counts only agent-loop spans — verified by arithmetic: `test_status_platform`'s 5,975 input tokens are exactly the agent's two iterations with nothing left for a judge call. Read token counts via `eval/tools/report-cost.py`, not the cost field.
+2. **Never ask an LLM judge to verify something the prompt did not request.** `test_champion_mastery_for_discovered_player` asked the agent for *"the top champion"* (singular) while its rubric graded *"reports at most 3 champion mastery entries"*. The judge sees the rubric and the response but not the prompt, so it penalised the agent for obeying instructions — failing on `stdio` and passing on `sse` purely on judge variance. Assert tool arguments structurally with `Expect.tools.called_with(...)` (subset matching, zero judge tokens) and keep rubrics to what the prompt actually asks for.
+
+- [ ] **Step 4: Update the ADR index**
+
+Add rows for ADR-0016 and ADR-0017 to the decisions index in `docs/knowledge/README.md`, matching the format of the existing ADR-0015 row.
+
+- [ ] **Step 5: Update the harness pattern guide and eval README**
+
+In `docs/knowledge/patterns/live-eval-harness.md`:
+- State that `stdio` runs the full suite and `sse` runs `eval/smoke.txt`, linking ADR-0017.
+- Add a "Measure the cost" section showing `cd eval && uv run python tools/report-cost.py test-reports/stdio.json`, and warn that the report's `cost_estimate` field is unreliable (link the gotcha).
+- Add a row to the triage table: **stale smoke set** — a spec in `smoke.txt` no longer resolves → `mcp-eval` prints `Skipping missing path` and the leg silently runs fewer tasks; fix the spec.
+
+In `eval/README.md`, document `smoke.txt` (what it is, that the sse leg runs it, how to add to it) and the cost-report command.
+
+- [ ] **Step 6: Update the add-live-eval skill**
+
+In `.claude/skills/add-live-eval/SKILL.md`, add a step near the end: after adding a scenario, consider whether it belongs in `eval/smoke.txt` — it does **only** if it proves something transport-specific (handshake, discovery, a round-trip on a newly added server, error propagation). Tool-logic scenarios do not; the `stdio` leg covers those, and every smoke entry is paid for on every dispatch.
+
+- [ ] **Step 7: Update the CHANGELOG**
+
+Add entries under the appropriate module sections of `CHANGELOG.md`, matching the existing format, marking the three tool changes as behavior changes:
+
+- `lol-mcp-server` — `lol_league_apex_by_tier` and `lol_challenges_by_player` now bound their list results (top 10 by default) and expose an optional `count` param plus `totalEntries` / `totalChallenges`.
+- `tft-mcp-server` — `tft_league_apex_by_tier` likewise; `tft_league_by_id` now reports `totalEntries` (unbounded, unchanged ordering).
+
+- [ ] **Step 8: Verify links resolve**
+
+Run: `grep -rn "ADR-0016\|ADR-0017\|smoke.txt\|report-cost.py" docs/ eval/README.md .claude/skills/add-live-eval/SKILL.md CHANGELOG.md`
+Expected: references in every file listed in this task, and no reference to a path that does not exist. Spot-check that `docs/knowledge/decisions/ADR-0016-bounded-list-results.md` and `ADR-0017-transport-scoped-live-eval.md` are on disk.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/ eval/README.md .claude/skills/add-live-eval/SKILL.md CHANGELOG.md
+git commit -m "docs: record bounded list results and transport-scoped eval coverage
+
+ADR-0016 (capped defaults, service-vs-port truncation), ADR-0017
+(stdio full / sse smoke), plus two gotchas: mcp-eval's cost_estimate is
+understated and judge-blind, and never grade a rubric on something the
+prompt did not ask for."
+```
+
+---
+
+## Task 8: Validate the reduction against the baseline
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md` (append measured results)
+
+**Interfaces:**
+- Consumes: `eval/tools/report-cost.py` from Task 6; the shipped changes from Tasks 1–5.
+- Produces: recorded measurements closing out the spec's success criteria.
+
+**Background for the implementer:** This task needs a live dispatch and therefore real credentials — `ANTHROPIC_API_KEY`, `LOL_DEV_API_KEY`, `TFT_DEV_API_KEY` as repository secrets. **Riot dev keys expire every 24 hours**; if the preflight step skips the run green with a notice naming a key, regenerate it and re-dispatch. Do not interpret a skipped run as a passing result.
+
+- [ ] **Step 1: Confirm the offline gate is green before spending anything**
+
+Run: `./gradlew build`
+Expected: BUILD SUCCESSFUL. Do not dispatch a live run against a red build.
+
+- [ ] **Step 2: Push the branch and dispatch the workflow**
+
+```bash
+git push -u origin HEAD
+gh workflow run live-eval.yml --ref "$(git rev-parse --abbrev-ref HEAD)"
+```
+
+- [ ] **Step 3: Wait for the run and confirm it actually executed**
+
+```bash
+gh run list --workflow=live-eval.yml -L 1
+gh run watch "$(gh run list --workflow=live-eval.yml -L 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+Expected: both matrix legs complete. Check the job summaries — the `stdio` leg must say `full suite` and the `sse` leg `transport smoke set (4 tasks)`. If either says `unknown scope`, the `EVAL_SCOPE` export in Task 5 did not take effect.
+
+- [ ] **Step 4: Download the artifacts and run the cost report**
+
+```bash
+RUN_ID="$(gh run list --workflow=live-eval.yml -L 1 --json databaseId --jq '.[0].databaseId')"
+gh run download "$RUN_ID" -D /tmp/after
+cd eval && uv run python tools/report-cost.py \
+  /tmp/after/mcpeval-reports-stdio/eval/test-reports/stdio.json \
+  /tmp/after/mcpeval-reports-sse/eval/test-reports/sse.json
+```
+
+- [ ] **Step 5: Check the results against the success criteria**
+
+| Criterion | Baseline | Target |
+|---|---|---|
+| `stdio` input tokens | 1,250,624 | ≤ 300,000 |
+| `sse` input tokens | 1,250,796 | ≤ 30,000 |
+| Combined real cost | ~$2.60 | ≤ $0.35 |
+| `test_champion_mastery_for_discovered_player` | failed on stdio | passes |
+| Any other task | — | no **new** failures |
+
+**Exclude `test_champion_rotation` from the pass/fail comparison.** It failed on both legs in the baseline because Riot returned unavailable — an infra flake by the harness's own triage table, not a defect. Post-change it runs on `stdio` only (it is not in the smoke set).
+
+If a criterion misses, do not adjust the target — find out why. The likeliest causes are that a `count` default did not take effect (check the tool table in the report: `lol_league_apex_by_tier` should now average a few hundred tokens, not ~17,900), or that a test not examined here holds a large payload.
+
+- [ ] **Step 6: Record the measured results in the spec**
+
+Append a `## Measured results` section to `docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md` with the run ID, date, the per-leg input/output token counts, the priced total, the per-tool table for `lol_league_apex_by_tier` before and after, and a pass/fail line per success criterion. The spec's criteria table is a claim; this section is the evidence.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
+git commit -m "docs(spec): record measured live-eval cost reduction
+
+Post-change dispatch measured against the run 30011353019 baseline."
+```
+
+---
+
+## Notes for the implementer
+
+**Three existing assertions will break by design**, because the services now return bounded copies rather than the port's instance. Each is replaced in the task that causes it:
+
+| Test | Assertion | Task |
+|---|---|---|
+| `lol …/league/application/LeagueServiceTest#getApexLeague_delegatesToPort` | `isSameAs` | 1 |
+| `tft …/league/application/LeagueServiceTest#getApexLeague_delegatesToPort`, `#getLeagueById_delegatesToPort` | `isSameAs` | 2 |
+| `lol …/challenges/application/ChallengesServiceTest#getChallengesByPlayer_resolvesPlayer_thenReturnsData` | `isSameAs` | 3 |
+
+Tool-layer tests keep `isSameAs` — they mock the service, so only the call arity changes.
+
+**If a WireMock adapter test needs editing, stop.** Adapters must keep fetching full payloads; truncation is an application concern. An adapter test that fails is a signal the change went into the wrong layer.

--- a/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
+++ b/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
@@ -264,3 +264,53 @@ Per the repo's hydrate/persist protocol:
   `smoke.txt`.
 - **CHANGELOG** — the three tool behavior changes, under the affected modules.
 - **CLAUDE.md** — only if the tool-surface description needs amending; tool count is unchanged.
+
+## Measured results
+
+Post-change dispatch: run [`30027872244`](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30027872244)
+on `perf/live-eval-token-cost`, 2026-07-23. Baseline: run `30011353019`. Both priced with
+`eval/tools/report-cost.py` at Claude Haiku 4.5 list rates ($1.00/MTok in, $5.00/MTok out) — not the
+report's own `cost_estimate` field, which understates by roughly 2×.
+
+### Tokens and cost
+
+| Leg | Tasks | Input | Output | Cost |
+|---|---|---|---|---|
+| `stdio` baseline | 24 | 1,250,624 | 10,246 | $1.3019 |
+| `stdio` after | 24 | 252,266 | 10,037 | $0.3025 |
+| `sse` baseline | 24 | 1,250,796 | ~10,200 | ~$1.30 |
+| `sse` after | 4 | 20,825 | 648 | $0.0241 |
+| **Combined after** | — | **273,091** | **10,685** | **$0.3265** |
+
+Input tokens fell 80% on `stdio` and 98% on `sse`. The two levers are separable: the payload bounds
+account for the `stdio` drop, and the transport smoke set for the rest of the `sse` drop.
+
+### The tool that drove it
+
+| Tool | Calls | Avg tokens/call | Total |
+|---|---|---|---|
+| `lol_league_apex_by_tier` baseline | 11 | 17,932 | 197,252 |
+| `lol_league_apex_by_tier` after | 11 | 638 | 7,018 |
+
+A 96% drop per call. Because the tool lands on turn 1 of a 3–4 iteration agent chain and its result
+is re-sent on every subsequent iteration, the saving compounds well beyond the raw payload size.
+`tft_league_apex_by_tier` (5 calls) and `lol_challenges_by_player` (1 call) now average 636 and 465
+tokens respectively.
+
+### Success criteria
+
+| Criterion | Target | Measured | Result |
+|---|---|---|---|
+| `stdio` input tokens | ≤ 300,000 | 252,266 | ✅ |
+| `sse` input tokens | ≤ 30,000 | 20,825 | ✅ |
+| Combined real cost | ≤ $0.35 | $0.3265 | ✅ |
+| `test_champion_mastery_for_discovered_player` | passes | passes on `stdio` | ✅ |
+| Any other task | no **new** failures | none | ✅ |
+
+The `sse` leg was green on all four smoke tasks, and its job summary correctly reported
+`transport smoke set (4 tasks)` while `stdio` reported `full suite` — the scope wiring works.
+
+**One failure, excluded by the criteria above:** `test_champion_rotation` failed on `stdio` because
+Riot returned "The Riot API is temporarily unavailable". It failed in the baseline on both legs for
+the same reason, so it is an infra flake by the harness's own triage table, not a regression. It is
+not in the smoke set, so post-change it runs on `stdio` only.

--- a/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
+++ b/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
@@ -1,0 +1,266 @@
+# Live-eval token cost reduction
+
+- **Date:** 2026-07-23
+- **Status:** Approved, ready for planning
+
+## Goal
+
+Cut the per-dispatch token spend of the live eval harness (`eval/`) by bounding two oversized MCP
+tool payloads and scoping the `sse` leg to a transport smoke set — then **measure** the reduction
+against a captured baseline.
+
+The payload change is not an eval-only accommodation. A tool that returns ~18,000 tokens by default
+is bad MCP design for any consumer; the evals merely made the cost visible.
+
+### Falsifiable success criteria
+
+Measured on a `workflow_dispatch` of `live-eval.yml` after the change lands:
+
+| Criterion | Baseline | Target |
+|---|---|---|
+| `stdio` input tokens | 1,250,624 | ≤ 300,000 |
+| `sse` input tokens | 1,250,796 | ≤ 30,000 |
+| Real cost per dispatch (both legs) | ~$2.60 | ≤ $0.35 |
+| Task outcomes | 24 tasks; 2 failures on `stdio`, 1 on `sse` | No **new** failures; `test_champion_mastery_for_discovered_player` now passes |
+
+Cost is computed at Claude Haiku 4.5's real rates (**$1.00/MTok input, $5.00/MTok output**), not
+from mcp-eval's `cost_estimate` field — see [Measurement](#measurement).
+
+## Baseline
+
+Captured from live-eval run `30011353019` (branch `fix/tft-eval-agent`, 2026-07-23), both legs:
+
+- **1,250,624 input / 10,246 output tokens** per transport (the two legs agree within 0.03%).
+- Input is **99.2%** of spend. Output is negligible; this is entirely a context-inflow problem.
+
+Emitted tool-result volume, aggregated across all 24 tasks:
+
+| Tool | Calls | Avg result | Total emitted |
+|---|---|---|---|
+| `lol_league_apex_by_tier` | 11 | ~17,900 tok | ~197k |
+| `tft_league_apex_by_tier` | 5 | ~14,800 tok | ~74k |
+| `lol_challenges_by_player` | 1 | ~9,700 tok | ~9.7k |
+| `lol_match_by_id` / `tft_match_by_id` | 2 | ~6,000 tok | ~12k |
+| all 16 other tools | 19 | ~90 tok | ~1.7k |
+
+The apex tools return the **entire CHALLENGER ladder (~300 entries)**. Because that lands on turn 1
+of a 3–4 iteration agent chain, it is re-sent on every subsequent iteration — roughly **58% of all
+input tokens**. The per-test costs show it starkly: any task touching apex costs ~77k input tokens;
+tasks with the same tool count and iteration depth that avoid it cost ~5.9k.
+
+`lol_challenges_by_player` has the same shape: a ~150-token useful head (`totalPoints`,
+`categoryPoints`) followed by a `challenges[]` array of ~500 rows that is ~99% of the payload.
+
+`lol_match_by_id` is **not** in scope. Full match detail *is* that tool's contract; capping it would
+gut the tool.
+
+### Rejected lever: prompt caching
+
+The obvious answer for repeated prompts does not apply here, for two independent reasons:
+
+1. `mcp-agent` 0.2.6 never emits `cache_control` (verified against the published wheel — zero
+   occurrences anywhere in the package). Enabling it would require patching or forking a dependency.
+2. Haiku 4.5's minimum cacheable prefix is **4,096 tokens**. The fixed system + tool-schema prefix
+   is ~2,800 tokens, so caching would silently never engage even if wired up.
+
+Recorded here so it is not re-investigated.
+
+## Part 1 — Bound the oversized payloads
+
+Three tools gain an optional `count` parameter and a **capped default**. Tool names and existing
+parameter descriptions are unchanged; only the default response size shrinks. An explicit large
+`count` still returns everything, so no data becomes unreachable.
+
+### `lol_league_apex_by_tier` / `tft_league_apex_by_tier`
+
+- New optional `Integer count`, following the established `lol_champion_mastery_by_player` idiom.
+- **Default: 10 entries.**
+- Entries are sorted by `leaguePoints` **descending** before slicing. Riot does not guarantee entry
+  order, so without this "top N" is meaningless and the eval's discovered subject changes run to run.
+- `LeagueList` gains a `totalEntries` field carrying the **pre-truncation** count (~5 tokens). Without
+  it an agent would reasonably conclude NA1 has only 10 Challengers.
+
+**Truncation happens in the application service** (`LeagueService.getApexLeague`), not the outbound
+adapter. This differs from `ChampionMasteryService`, which passes `count` down to its port — Riot's
+Champion-Mastery-V4 has a native `count` query parameter, whereas League-V4 and TFT-League-V1 apex
+endpoints always return the whole league. Same MCP-level contract, two different implementation
+layers, chosen by whether Riot supports it upstream. The adapter stays a dumb mapper and the hexagon
+dependency rules are untouched.
+
+### `lol_challenges_by_player`
+
+- New optional `Integer count` bounding the `challenges[]` array **only**. `totalPoints` and
+  `categoryPoints` always return in full — they are the summary and cost ~150 tokens.
+- **Default: 10 entries**, sorted by `percentile` **ascending** (lower percentile = rarer
+  achievement), so the capped view is the player's strongest challenges.
+- `ChallengesPlayerData` gains `totalChallenges`, pre-truncation.
+- Truncation in `ChallengesService`.
+
+### Explicitly out of scope
+
+`tft_league_rated_ladder_by_queue` and `tft_league_by_id` have the same unbounded shape but are
+called by no eval, so capping them saves nothing against this goal. The ADR records them as
+known-unbounded with the same remedy available. (`tft_league_entries_by_tier` is already page-bounded
+by Riot.)
+
+### Expected effect
+
+Apex ~18k → ~600 tokens; challenges ~8.7k → ~250. With the per-iteration re-send multiplier, per-
+transport input drops from ~1.25M to roughly **240k**.
+
+## Part 2 — Transport-scoped eval coverage
+
+`stdio` keeps the full 24-task suite. `sse` runs a smoke set proving the transport wiring, not the
+tool logic — the two legs currently run identical tasks and produce identical results, paying twice
+for one signal.
+
+### Selection mechanism
+
+`mcp-eval run` accepts multiple positional path specs, including pytest-style `file.py::func`. It has
+**no `-k`, no markers, and no tag system** (verified against `mcp_eval/runner.py` in the pinned
+0.1.10 release), so the subset must be expressed as explicit paths.
+
+The list lives in **`eval/smoke.txt`** — newline-delimited `file.py::func` specs, `#` comments
+allowed — not hardcoded in CI YAML, so selection sits where someone adding a test will see it. The
+workflow feeds it to `mcp-eval` via `xargs`.
+
+### The smoke set
+
+Chosen for what is genuinely transport-specific: connection, discovery, a round-trip per server, and
+error propagation. That last one matters most — `live-eval.yml` already notes that Spring AI's MCP
+layer masks server-side exceptions over sse.
+
+| Task | Proves | Cost |
+|---|---|---|
+| `test_handshake.py::test_lists_tools` | sse handshake + tool discovery | 2.9k |
+| `test_status.py::test_status_platform` | LoL round-trip over sse | 5.9k |
+| `test_tft_status.py::test_tft_status_platform` | TFT round-trip over sse (separate port) | 5.3k |
+| `test_canaries.py::test_invalid_platform` | error surfaces through the transport | 5.9k |
+
+≈ 20k input tokens. No test files move; all four stay where they are. None touch apex, so their cost
+is stable after Part 1.
+
+### Workflow changes
+
+- The `[stdio, sse]` matrix is unchanged — both legs still build jars, run in parallel, and upload
+  artifacts.
+- Only the run step differs: `stdio` passes `tests/`; `sse` passes the specs from `smoke.txt`.
+- **The job summary must name the set that ran and its task count.** Today both legs print an
+  identical "✅ All live evals passed"; post-change that would let a green sse leg be mistaken for
+  full coverage.
+
+## Part 3 — Fix the `test_champion_mastery_for_discovered_player` rubric
+
+This task failed on `stdio` and passed on `sse` in the baseline. The cause is **not** nondeterminism
+— it is a prompt/rubric mismatch, and sse passed only on judge variance.
+
+- The prompt asks for *"the top champion and its mastery point value"* — singular.
+- The rubric grades *"The answer reports at most 3 champion mastery entries…"*.
+
+The agent obeyed the prompt, reported one champion, and the judge marked it down for not listing
+three. The rubric asserts on something the prompt never requested.
+
+### Fix
+
+Move the `count`-parameter assertion out of the LLM judge and into a structural check, then narrow
+the rubric to what the prompt actually asks for:
+
+- Add `Expect.tools.called_with("lol_champion_mastery_by_player", {"count": 3})`. `ToolCalledWith`
+  does **subset** argument matching (verified in `mcp_eval/evaluators/tool_called_with.py`), so the
+  other parameters need not be named. This is deterministic and costs zero judge tokens.
+- Remove the "at most 3 entries" clause from the rubric. Retain: names the top champion by points,
+  non-negative point value, says so clearly if the player has no mastery data, no tool error.
+
+The prompt is left alone — it already requests the top-3 limit, which is what makes the structural
+assertion meaningful.
+
+The general lesson (for `gotchas.md`): **never ask an LLM judge to verify something the prompt did
+not request.** The judge grades the response against the rubric without seeing that the prompt asked
+for less.
+
+### Not in scope
+
+`test_champion_rotation` failed on both legs because Riot returned unavailable. That is an infra
+flake by the harness's own triage table, not a defect. It must be excluded from the post-change
+comparison, not "fixed". (It is not in the smoke set, so post-change it runs on `stdio` only.)
+
+## Part 4 — Eval prompt impact
+
+**The eval prompts do not change.** Because Part 1 caps the *default* rather than adding an opt-in
+parameter, `"Get the CHALLENGER apex league… pick any one player"` works verbatim and simply receives
+10 entries. This was the main reason for choosing a capped default over a purely additive parameter.
+
+One exception. `test_apex_challenger` asks *"How many entries does it contain?"* with a rubric
+accepting "a non-zero number of entries". Post-change that silently becomes an assertion about a
+truncated view. Retarget the rubric at `totalEntries` so it keeps asserting the real ladder size;
+otherwise the test quietly gets weaker.
+
+## Testing
+
+The offline suite (`./gradlew build`) remains the CI gate and stays key-free and network-free.
+
+**Application services — in-memory port fakes.** For `LeagueService` (LoL and TFT) and
+`ChallengesService`:
+
+- default cap applied when `count` is `null`
+- explicit `count` honoured
+- `count` exceeding available entries returns everything, without error
+- zero and negative `count` **clamp to the default** (10) rather than returning an empty list or
+  throwing — assert this explicitly so the behavior is pinned
+- sort order is deterministic and correct (`leaguePoints` desc; `percentile` asc)
+- `totalEntries` / `totalChallenges` reflect the **pre-truncation** size
+- empty and `null` collections do not throw
+- the `percentile` comparator is **null-safe** — Riot omits `percentile` on some challenges, and a
+  naive comparator NPEs on live data while passing on hand-built fixtures
+
+**Outbound adapters.** The existing WireMock tests must pass **completely unchanged**. That is the
+signal the layer boundary held: adapters still fetch full payloads, and truncation is a service
+concern. If an adapter test needs editing, the boundary leaked and the design is wrong.
+
+**Gates.** JaCoCo will require the new branches covered. ArchUnit is unaffected — no new
+cross-context dependencies. Spotless as usual.
+
+## Measurement
+
+Commit `eval/tools/report-cost.py`: reads a run's report JSON and prints per-test and per-tool token
+tables plus a total. Evals run regularly, so this turns a one-off investigation into a standing
+capability rather than analysis to be redone by hand each time.
+
+**It must report token counts and cost computed at real Haiku 4.5 rates.** mcp-eval's own
+`cost_estimate` field is unreliable here on two counts:
+
+1. It prices at a **~$0.50/MTok fallback rate**, understating the real Haiku 4.5 bill by roughly 2×
+   (the baseline's reported `$0.6304` is actually ~$1.30).
+2. It **excludes LLM-judge calls entirely** — verified: `test_status_platform`'s 5,975 input tokens
+   account for exactly the agent's two iterations with nothing left over for a judge call.
+
+### Validation procedure
+
+1. Record the baseline (already captured above from run `30011353019`).
+2. Land Parts 1–4; confirm `./gradlew build` is green.
+3. Dispatch `live-eval.yml`; download both artifacts.
+4. Run `report-cost.py` over each leg's JSON.
+5. Compare against the success criteria table, **excluding `test_champion_rotation`** from the
+   pass/fail comparison as a known infra flake.
+
+## Documentation and knowledge persistence
+
+Per the repo's hydrate/persist protocol:
+
+- **ADR-0016 — bounded list results for MCP tools.** Why a capped default over an opt-in parameter;
+  why apex and challenges truncate in the service while champion mastery truncates at the port; the
+  `totalEntries` / `totalChallenges` convention; `tft_league_rated_ladder_by_queue` and
+  `tft_league_by_id` recorded as known-unbounded.
+- **ADR-0017 — transport-scoped live-eval coverage.** What the sse smoke set does and does not prove,
+  and why the full suite on both transports was redundant. Cross-reference ADR-0012.
+- **`gotchas.md`** — two entries:
+  - mcp-eval's `cost_estimate` uses a fallback rate (understates Haiku 4.5 by ~2×) and omits judge
+    tokens; read token counts, not the cost field.
+  - Never ask an LLM judge to verify something the prompt did not request (the champion-mastery
+    rubric mismatch).
+- **`patterns/live-eval-harness.md`** and **`eval/README.md`** — `smoke.txt` and how to read a cost
+  report.
+- **`add-live-eval` skill** — prompt the author to consider whether a new scenario belongs in
+  `smoke.txt`.
+- **CHANGELOG** — the three tool behavior changes, under the affected modules.
+- **CLAUDE.md** — only if the tool-surface description needs amending; tool count is unchanged.

--- a/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
+++ b/docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md
@@ -282,6 +282,15 @@ report's own `cost_estimate` field, which understates by roughly 2×.
 | `sse` after | 4 | 20,825 | 648 | $0.0241 |
 | **Combined after** | — | **273,091** | **10,685** | **$0.3265** |
 
+**Caveat:** these figures are agent-loop token counts read from the report's raw `metrics` and
+repriced at Haiku 4.5's real rates — `report-cost.py` fixes the *rate* `cost_estimate` gets wrong, not
+the fact that both it and the raw metrics it reads are judge-blind. Separate LLM-judge token spend
+(each `Expect.judge.llm(...)` assertion makes its own call) is not captured here, so "Combined [real]
+cost $0.3265" is the measured agent-loop cost, not the full dispatch cost including judge calls. The
+80%/98% reductions and the conclusion are unaffected — they are dominated by input tokens on the
+agent side, which is exactly what shrank — but the absolute dollar figures understate the true total
+by whatever the judge calls cost.
+
 Input tokens fell 80% on `stdio` and 98% on `sse`. The two levers are separable: the payload bounds
 account for the `stdio` drop, and the transport smoke set for the rest of the `sse` drop.
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -36,3 +36,27 @@ each server with its own key on its own port, and use `mcpeval.sse.yaml` — see
 
 `ANTHROPIC_API_KEY` is required (agent + judge). It is **separate** from `CLAUDE_CODE_OAUTH_TOKEN`,
 which this harness never uses. Reports land in `test-reports/`.
+
+## Transport scope: `smoke.txt`
+
+CI does not run the same coverage on both legs. `stdio` runs the full suite (`tests/`); `sse` runs
+only the four-task set listed in [`smoke.txt`](smoke.txt) — one spec per line
+(`file.py::function_name`), `#` comments and blank lines ignored. The `sse` leg proves the transport
+wiring (handshake/discovery, one tool round-trip per server, error propagation); tool-logic coverage
+comes entirely from `stdio`. See
+[ADR-0017](../docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md).
+
+Add a test to `smoke.txt` only if it proves something transport-specific — a new server's handshake,
+a new round-trip, error propagation. A tool-logic scenario belongs only in `tests/`; every line in
+`smoke.txt` is paid for on every `sse` dispatch.
+
+## Measure the cost
+
+`eval/tools/report-cost.py` summarises a report's real token spend and cost, priced at Claude Haiku
+4.5's actual rates rather than the report's own (understated, judge-blind)
+`cost_estimate` field:
+
+```bash
+uv run python tools/report-cost.py test-reports/stdio.json
+uv run python tools/report-cost.py test-reports/stdio.json test-reports/sse.json
+```

--- a/eval/README.md
+++ b/eval/README.md
@@ -52,9 +52,10 @@ a new round-trip, error propagation. A tool-logic scenario belongs only in `test
 
 ## Measure the cost
 
-`eval/tools/report-cost.py` summarises a report's real token spend and cost, priced at Claude Haiku
-4.5's actual rates rather than the report's own (understated, judge-blind)
-`cost_estimate` field:
+`eval/tools/report-cost.py` summarises a report's token spend and cost, priced at Claude Haiku 4.5's
+actual rates rather than the report's own (understated) `cost_estimate` field. That fixes the rate
+only — both `cost_estimate` and this script read agent-loop metrics that omit separate LLM-judge
+token spend, which remains unmeasured either way:
 
 ```bash
 uv run python tools/report-cost.py test-reports/stdio.json

--- a/eval/smoke.txt
+++ b/eval/smoke.txt
@@ -1,0 +1,19 @@
+# Transport smoke set — run on the sse leg instead of the full suite.
+#
+# These four tasks prove the *transport wiring*, not the tool logic: the stdio
+# leg runs the full suite against the same jars, so anything below the transport
+# layer is already covered there. Keep this list small — every entry is paid for
+# on every dispatch. See ADR-0017.
+#
+# One "file.py::function" spec per line; blank lines and # comments are ignored.
+
+# sse handshake and tool discovery
+tests/test_handshake.py::test_lists_tools
+
+# a tool round-trip on each server (the two run on different ports)
+tests/test_status.py::test_status_platform
+tests/test_tft_status.py::test_tft_status_platform
+
+# errors must surface through the transport — Spring AI's MCP layer only reports
+# a generic "Error invoking method" over sse, so this is the leg's weak spot
+tests/test_canaries.py::test_invalid_platform

--- a/eval/tests/test_championmastery.py
+++ b/eval/tests/test_championmastery.py
@@ -1,5 +1,9 @@
 """Champion mastery live eval. The subject is discovered from the CHALLENGER
-ladder, exercising the player-keyed path plus the optional top-N count param."""
+ladder, exercising the player-keyed path plus the optional top-N count param.
+
+The count param is asserted structurally, not through the judge: the prompt asks
+for a single champion, so a rubric that graded "reports 3 entries" would penalise
+the agent for obeying the prompt. See gotchas.md."""
 
 from mcp_eval import task, Expect
 
@@ -16,14 +20,20 @@ async def test_champion_mastery_for_discovered_player(agent, session):
         Expect.tools.was_called("lol_champion_mastery_by_player"),
         name="champion_mastery_called",
     )
+    # Structural, not judged: proves the top-N count param reached the tool.
+    await session.assert_that(
+        Expect.tools.called_with("lol_champion_mastery_by_player", {"count": 3}),
+        name="champion_mastery_count_passed",
+    )
     await session.assert_that(
         Expect.judge.llm(
             rubric=(
-                "The answer reports at most 3 champion mastery entries, each "
-                "with a non-negative mastery point value, and names the top "
-                "champion by points. If the player has no mastery data, it "
-                "clearly says so. It must not report impossible values "
-                "(negative points) or a tool error."
+                "The answer names the top champion by mastery points and gives "
+                "its mastery point value, which must be non-negative. If the "
+                "player has no mastery data, it clearly says so instead. It "
+                "must not report a tool error. Reporting only the single top "
+                "champion is correct and expected — do not require additional "
+                "champions to be listed."
             ),
             min_score=0.7,
         ),

--- a/eval/tests/test_league.py
+++ b/eval/tests/test_league.py
@@ -8,7 +8,9 @@ from mcp_eval import task, Expect
 async def test_apex_challenger(agent, session):
     response = await agent.generate_str(
         "Get the CHALLENGER apex league for the RANKED_SOLO_5x5 queue on NA1. "
-        "How many entries does it contain, and name one player in it?"
+        "The tool caps the entries it returns, so report the total number of "
+        "players in the league (the totalEntries field), and name one player "
+        "from the entries you received."
     )
     await session.assert_that(
         Expect.tools.was_called("lol_league_apex_by_tier"),
@@ -17,17 +19,20 @@ async def test_apex_challenger(agent, session):
     await session.assert_that(
         Expect.judge.llm(
             rubric=(
-                "The answer reports a CHALLENGER league with a non-zero number "
-                "of entries and identifies at least one entry in it. A PUUID, "
-                "summoner id, or LP/rank is sufficient identification — Riot no "
-                "longer exposes human-readable summoner names in league entries, "
+                "The answer reports a CHALLENGER league whose total size is well "
+                "above the number of entries actually returned — a real ladder has "
+                "on the order of hundreds of players, so a reported total of only "
+                "about ten means the truncated list was mistaken for the whole "
+                "league and must fail. It also identifies at least one entry. A "
+                "PUUID, summoner id, or LP/rank is sufficient identification — Riot "
+                "no longer exposes human-readable summoner names in league entries, "
                 "so do not require a display name. It does not report an error or "
                 "an empty league."
             ),
             min_score=0.7,
         ),
         response=response,
-        name="apex_populated",
+        name="apex_reports_true_ladder_size",
     )
 
 

--- a/eval/tools/report-cost.py
+++ b/eval/tools/report-cost.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Summarise the token spend of a live-eval run.
+
+Reads an mcp-eval JSON report and prints per-test and per-tool token tables plus
+a priced total.
+
+Deliberately ignores the report's own ``cost_estimate`` field: it prices at a
+~$0.50/MTok fallback rate (understating Claude Haiku 4.5 by roughly 2x) and
+excludes LLM-judge calls entirely. We price from raw token counts instead, so
+the number moves for the same reason the bill does.
+
+Usage:
+    cd eval && uv run python tools/report-cost.py test-reports/stdio.json
+    cd eval && uv run python tools/report-cost.py test-reports/stdio.json test-reports/sse.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Claude Haiku 4.5 list rates, USD per million tokens.
+INPUT_PER_MTOK = 1.00
+OUTPUT_PER_MTOK = 5.00
+
+
+def price(input_tokens: int, output_tokens: int) -> float:
+    """Cost in USD of the given token counts at Haiku 4.5 rates."""
+    return (input_tokens * INPUT_PER_MTOK + output_tokens * OUTPUT_PER_MTOK) / 1_000_000
+
+
+def token_counts(test: dict) -> tuple[int, int]:
+    """Input and output tokens for one test, tolerating both metric layouts."""
+    metrics = test.get("metrics") or {}
+    llm = metrics.get("llm_metrics") or {}
+    return (
+        llm.get("input_tokens", metrics.get("input_tokens", 0)) or 0,
+        llm.get("output_tokens", metrics.get("output_tokens", 0)) or 0,
+    )
+
+
+def report(path: Path) -> tuple[int, int]:
+    """Print the tables for one report file; return its (input, output) totals."""
+    tests = json.loads(path.read_text(encoding="utf-8")).get("decorator_tests", [])
+    if not tests:
+        print(f"{path}: no decorator_tests found", file=sys.stderr)
+        return 0, 0
+
+    rows = []
+    tool_sizes: dict[str, list[int]] = defaultdict(list)
+    total_in = total_out = 0
+
+    for test in tests:
+        tokens_in, tokens_out = token_counts(test)
+        total_in += tokens_in
+        total_out += tokens_out
+        metrics = test.get("metrics") or {}
+        calls = metrics.get("tool_calls") or []
+        rows.append(
+            (
+                price(tokens_in, tokens_out),
+                tokens_in,
+                tokens_out,
+                len(calls),
+                metrics.get("iteration_count"),
+                bool(test.get("passed")),
+                test.get("test_name", "?"),
+            )
+        )
+        for call in calls:
+            # Approximate the emitted result size in tokens. ~4 chars per token is
+            # close enough to rank tools by payload weight.
+            tool_sizes[call.get("name", "?")].append(len(json.dumps(call.get("result", {}))) // 4)
+
+    print(f"\n=== {path.name} ===")
+    print(
+        f"{len(tests)} tasks | in {total_in:,} | out {total_out:,} "
+        f"| ${price(total_in, total_out):.4f} @ Haiku 4.5 rates"
+    )
+
+    print(f"\n{'cost':>9}  {'in':>9}  {'out':>6}  {'calls':>5}  {'iter':>4}  ok  test")
+    for cost, tokens_in, tokens_out, calls, iterations, passed, name in sorted(rows, reverse=True):
+        print(
+            f"${cost:>8.4f}  {tokens_in:>9,}  {tokens_out:>6,}  {calls:>5}  "
+            f"{str(iterations or '-'):>4}  {'y' if passed else 'N':>2}  {name}"
+        )
+
+    if tool_sizes:
+        print(f"\n{'tool':<42} {'n':>3}  {'avg tok':>8}  {'total tok':>10}")
+        for name, sizes in sorted(tool_sizes.items(), key=lambda kv: -sum(kv[1])):
+            print(f"{name:<42} {len(sizes):>3}  {sum(sizes) // len(sizes):>8,}  {sum(sizes):>10,}")
+
+    return total_in, total_out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    grand_in = grand_out = 0
+    reported = 0
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.is_file():
+            print(f"skipping missing file: {path}", file=sys.stderr)
+            continue
+        tokens_in, tokens_out = report(path)
+        grand_in += tokens_in
+        grand_out += tokens_out
+        reported += 1
+
+    if reported > 1:
+        print("\n=== combined ===")
+        print(
+            f"in {grand_in:,} | out {grand_out:,} "
+            f"| ${price(grand_in, grand_out):.4f} @ Haiku 4.5 rates"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/eval/tools/report-cost.py
+++ b/eval/tools/report-cost.py
@@ -5,9 +5,15 @@ Reads an mcp-eval JSON report and prints per-test and per-tool token tables plus
 a priced total.
 
 Deliberately ignores the report's own ``cost_estimate`` field: it prices at a
-~$0.50/MTok fallback rate (understating Claude Haiku 4.5 by roughly 2x) and
-excludes LLM-judge calls entirely. We price from raw token counts instead, so
-the number moves for the same reason the bill does.
+~$0.50/MTok fallback rate, understating Claude Haiku 4.5 by roughly 2x. We
+price from the report's raw token counts at Haiku 4.5's real rates instead,
+so the number moves for the same reason the bill does.
+
+That fixes the *rate* error only. The raw metrics this script reads are
+judge-blind: they cover the agent loop, not the separate LLM-judge call each
+``Expect.judge.llm(...)`` assertion makes. Judge token spend is therefore
+unmeasured by both ``cost_estimate`` and this script's totals — a remaining
+limitation, not something this tool solves.
 
 Usage:
     cd eval && uv run python tools/report-cost.py test-reports/stdio.json
@@ -70,8 +76,10 @@ def report(path: Path) -> tuple[int, int]:
             )
         )
         for call in calls:
-            # Approximate the emitted result size in tokens. ~4 chars per token is
-            # close enough to rank tools by payload weight.
+            # Approximate the emitted result size in tokens (chars/4). This is a rough
+            # proxy computed from the call's JSON result, not a metered token count like
+            # the priced totals above — close enough to rank tools by payload weight, but
+            # not directly comparable to the llm_metrics-based numbers in the tables above.
             tool_sizes[call.get("name", "?")].append(len(json.dumps(call.get("result", {}))) // 4)
 
     print(f"\n=== {path.name} ===")
@@ -88,9 +96,11 @@ def report(path: Path) -> tuple[int, int]:
         )
 
     if tool_sizes:
-        print(f"\n{'tool':<42} {'n':>3}  {'avg tok':>8}  {'total tok':>10}")
+        print(f"\n{'tool':<42} {'n':>3}  {'approx tok/call (chars/4)':>26}  {'approx total (chars/4)':>22}")
         for name, sizes in sorted(tool_sizes.items(), key=lambda kv: -sum(kv[1])):
-            print(f"{name:<42} {len(sizes):>3}  {sum(sizes) // len(sizes):>8,}  {sum(sizes):>10,}")
+            print(
+                f"{name:<42} {len(sizes):>3}  {sum(sizes) // len(sizes):>26,}  {sum(sizes):>22,}"
+            )
 
     return total_in, total_out
 

--- a/lol-mcp-server/CHANGELOG.md
+++ b/lol-mcp-server/CHANGELOG.md
@@ -6,6 +6,22 @@ Scoped to this module. Repo-wide changes live in the [root CHANGELOG](../CHANGEL
 libraries keep their own. Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/);
 versioning: [SemVer](https://semver.org/spec/v2.0.0.html), pre-1.0 (breaking → minor).
 
+## [0.3.0] - unreleased
+
+Live-eval token cost reduction — bounds two list-returning tools whose default response size was
+driving up per-call token cost for any MCP consumer, not only the eval harness. See
+[the design spec](../docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md) and
+[ADR-0016](../docs/knowledge/decisions/ADR-0016-bounded-list-results.md).
+
+### Changed
+- **Breaking:** `lol_league_apex_by_tier` now returns only the **top 10 entries by league points**
+  by default (previously the entire apex ladder — ~300 entries for CHALLENGER). An optional `count`
+  param requests more; the response now stamps `totalEntries` with the pre-truncation ladder size.
+- **Breaking:** `lol_challenges_by_player`'s per-challenge list is bounded the same way: the top 10
+  challenges by `percentile` ascending (rarer first) by default, an optional `count` param, and
+  `totalChallenges` stamped with the pre-truncation count. `totalPoints` and `categoryPoints` are
+  unaffected — they were always returned in full.
+
 ## [0.2.0] - 2026-07-19
 
 Sub-project 1b — LoL parity: breadth. Five new contexts plus the match context's first inbound

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesTool.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesTool.java
@@ -20,7 +20,7 @@ public class ChallengesTool {
     @McpTool(
             name = "lol_challenges_by_player",
             description =
-                    "Get a League of Legends player's challenge standing: total and per-category points, and per-challenge progress. Per-challenge progress returns the 10 strongest challenges unless a larger count is requested; totals and category points are always complete.")
+                    "Get a League of Legends player's challenge standing: total and per-category points, and per-challenge progress. Per-challenge progress returns the lowest-percentile challenges first, capped at 10 unless a larger count is requested; totals and category points are always complete.")
     public ChallengesPlayerData getChallengesByPlayer(
             @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
             @McpToolParam(description = "The player as a Riot ID (GameName#TAG) or a raw PUUID", required = true)

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesTool.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesTool.java
@@ -20,13 +20,18 @@ public class ChallengesTool {
     @McpTool(
             name = "lol_challenges_by_player",
             description =
-                    "Get a League of Legends player's challenge standing: total and per-category points, and per-challenge progress.")
+                    "Get a League of Legends player's challenge standing: total and per-category points, and per-challenge progress. Per-challenge progress returns the 10 strongest challenges unless a larger count is requested; totals and category points are always complete.")
     public ChallengesPlayerData getChallengesByPlayer(
             @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
             @McpToolParam(description = "The player as a Riot ID (GameName#TAG) or a raw PUUID", required = true)
-                    String player) {
+                    String player,
+            @McpToolParam(
+                            description =
+                                    "Optional: return only the top N individual challenges by percentile; defaults to 10",
+                            required = false)
+                    Integer count) {
         RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
         log.info("MCP Tool - Getting challenge data for a player on platform: {}", platform);
-        return challengesService.getChallengesByPlayer(platform, player);
+        return challengesService.getChallengesByPlayer(platform, player, count);
     }
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/application/ChallengesService.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/application/ChallengesService.java
@@ -3,7 +3,10 @@ package com.muddl.riot.lol.challenges.application;
 import com.muddl.riot.account.identity.PlayerIdentityResolver;
 import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.lol.challenges.application.port.ChallengesPort;
+import com.muddl.riot.lol.challenges.domain.ChallengeProgress;
 import com.muddl.riot.lol.challenges.domain.ChallengesPlayerData;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,12 +20,44 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChallengesService {
 
+    /** Default number of individual challenges returned when the caller does not specify a count. */
+    private static final int DEFAULT_CHALLENGES = 10;
+
     private final ChallengesPort challengesPort;
     private final PlayerIdentityResolver identityResolver;
 
-    public ChallengesPlayerData getChallengesByPlayer(RiotApiPlatformUri platform, String player) {
+    public ChallengesPlayerData getChallengesByPlayer(RiotApiPlatformUri platform, String player, Integer count) {
         String puuid = identityResolver.resolvePuuid(player);
         log.info("Fetching challenge data on platform: {}", platform);
-        return challengesPort.getPlayerDataByPuuid(platform, puuid);
+        int limit = (count == null || count <= 0) ? DEFAULT_CHALLENGES : count;
+        return boundChallenges(challengesPort.getPlayerDataByPuuid(platform, puuid), limit);
+    }
+
+    /**
+     * Returns a copy of {@code data} holding only the {@code limit} strongest challenges, with
+     * {@code totalChallenges} stamped to the pre-truncation size. {@code totalPoints} and
+     * {@code categoryPoints} are always returned in full — they are the summary and cost almost
+     * nothing, while Riot's per-challenge array runs to ~500 rows and is ~99% of the payload.
+     *
+     * <p>Sorted by percentile <em>ascending</em>, because a lower percentile is a rarer
+     * achievement. The comparator must tolerate nulls: Riot omits {@code percentile} on challenges
+     * a player has not progressed on. See ADR-0016.
+     */
+    private static ChallengesPlayerData boundChallenges(ChallengesPlayerData data, int limit) {
+        if (data == null) {
+            return null;
+        }
+        List<ChallengeProgress> challenges = data.getChallenges();
+        if (challenges == null) {
+            return data.toBuilder().challenges(List.of()).totalChallenges(0).build();
+        }
+        return data.toBuilder()
+                .challenges(challenges.stream()
+                        .sorted(Comparator.comparing(
+                                ChallengeProgress::getPercentile, Comparator.nullsLast(Comparator.naturalOrder())))
+                        .limit(limit)
+                        .toList())
+                .totalChallenges(challenges.size())
+                .build();
     }
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengesPlayerData.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/challenges/domain/ChallengesPlayerData.java
@@ -1,5 +1,6 @@
 package com.muddl.riot.lol.challenges.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import java.util.Map;
@@ -10,12 +11,21 @@ import lombok.NoArgsConstructor;
 
 /** A player's challenge standing: totals, per-category points, and per-challenge progress. */
 @Data
-@Builder
-@NoArgsConstructor
+@Builder(toBuilder = true)
+// Forces bean-style deserialization: without it Jackson picks the Lombok all-args constructor as a
+// properties-based creator and maps the absent totalChallenges to null, failing on the primitive.
+// See gotchas.md, "Adding a primitive field to an existing Riot-mapped DTO".
+@NoArgsConstructor(onConstructor_ = @JsonCreator)
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChallengesPlayerData {
     private ChallengePoints totalPoints;
     private Map<String, ChallengePoints> categoryPoints;
     private List<ChallengeProgress> challenges;
+
+    /**
+     * Total challenges returned by Riot before any {@code count} bound was applied. Lets a caller
+     * that received a capped {@link #challenges} list know how many exist.
+     */
+    private int totalChallenges;
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueTool.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueTool.java
@@ -40,7 +40,7 @@ public class LeagueTool {
     @McpTool(
             name = "lol_league_apex_by_tier",
             description =
-                    "Get a League of Legends apex league (CHALLENGER, GRANDMASTER, or MASTER) for a ranked queue.")
+                    "Get a League of Legends apex league (CHALLENGER, GRANDMASTER, or MASTER) for a ranked queue. Returns the top 10 entries by league points unless a larger count is requested.")
     public LeagueList getApexLeague(
             @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
             @McpToolParam(description = "The apex tier: CHALLENGER, GRANDMASTER, or MASTER", required = true)
@@ -48,11 +48,15 @@ public class LeagueTool {
             @McpToolParam(
                             description = "The ranked queue, e.g. RANKED_SOLO_5x5 (default) or RANKED_FLEX_SR",
                             required = false)
-                    String queueStr) {
+                    String queueStr,
+            @McpToolParam(
+                            description = "Optional: return only the top N entries by league points; defaults to 10",
+                            required = false)
+                    Integer count) {
         RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
         ApexTier tier = ApexTier.valueOf(tierStr.toUpperCase());
         String queue = (queueStr == null || queueStr.isBlank()) ? DEFAULT_QUEUE : queueStr;
         log.info("MCP Tool - Getting {} apex league for queue {} on platform: {}", tier, queue, platform);
-        return leagueService.getApexLeague(platform, tier, queue);
+        return leagueService.getApexLeague(platform, tier, queue, count);
     }
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/application/LeagueService.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/application/LeagueService.java
@@ -5,7 +5,9 @@ import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.lol.league.application.port.LeaguePort;
 import com.muddl.riot.lol.league.domain.ApexTier;
 import com.muddl.riot.lol.league.domain.LeagueEntry;
+import com.muddl.riot.lol.league.domain.LeagueItem;
 import com.muddl.riot.lol.league.domain.LeagueList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +34,40 @@ public class LeagueService {
         return leaguePort.getLeagueEntriesByPuuid(platform, puuid);
     }
 
-    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier, String queue) {
+    /** Default number of apex entries returned when the caller does not specify a count. */
+    private static final int DEFAULT_APEX_ENTRIES = 10;
+
+    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier, String queue, Integer count) {
         log.info("Fetching {} apex league for queue {} on platform: {}", tier, queue, platform);
-        return leaguePort.getApexLeague(platform, tier, queue);
+        int limit = (count == null || count <= 0) ? DEFAULT_APEX_ENTRIES : count;
+        return boundEntries(leaguePort.getApexLeague(platform, tier, queue), limit);
+    }
+
+    /**
+     * Returns a copy of {@code league} holding only the top {@code limit} entries by league points,
+     * with {@code totalEntries} stamped to the pre-truncation size.
+     *
+     * <p>Riot's League-V4 apex endpoint has no server-side count parameter (unlike
+     * Champion-Mastery-V4, where the bound is pushed down to the port), so the bound is applied
+     * here in the application layer. Riot does not guarantee entry order, so entries are sorted
+     * before slicing — otherwise "top N" is meaningless and a discovered subject would change
+     * between runs. See ADR-0016.
+     */
+    private static LeagueList boundEntries(LeagueList league, int limit) {
+        if (league == null) {
+            return null;
+        }
+        List<LeagueItem> entries = league.getEntries();
+        if (entries == null) {
+            return league.toBuilder().entries(List.of()).totalEntries(0).build();
+        }
+        return league.toBuilder()
+                .entries(entries.stream()
+                        .sorted(Comparator.comparingInt(LeagueItem::getLeaguePoints)
+                                .reversed())
+                        .limit(limit)
+                        .toList())
+                .totalEntries(entries.size())
+                .build();
     }
 }

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/domain/LeagueList.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/domain/LeagueList.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 /** An apex league (challenger/grandmaster/master) for one queue (Riot League-V4). */
 @Data
 @Builder(toBuilder = true)
+// Forces bean-style deserialization: without it Jackson picks the Lombok all-args constructor as a
+// properties-based creator and maps the absent totalEntries to null, failing on the primitive. See
+// gotchas.md, "Adding a primitive field to an existing Riot-mapped DTO".
 @NoArgsConstructor(onConstructor_ = @JsonCreator)
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/domain/LeagueList.java
+++ b/lol-mcp-server/src/main/java/com/muddl/riot/lol/league/domain/LeagueList.java
@@ -1,5 +1,6 @@
 package com.muddl.riot.lol.league.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -9,8 +10,8 @@ import lombok.NoArgsConstructor;
 
 /** An apex league (challenger/grandmaster/master) for one queue (Riot League-V4). */
 @Data
-@Builder
-@NoArgsConstructor
+@Builder(toBuilder = true)
+@NoArgsConstructor(onConstructor_ = @JsonCreator)
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LeagueList {
@@ -19,4 +20,10 @@ public class LeagueList {
     private String name;
     private String queue;
     private List<LeagueItem> entries;
+
+    /**
+     * Total entries in the league before any {@code count} bound was applied. Lets a caller that
+     * received a capped {@link #entries} list still know the real ladder size.
+     */
+    private int totalEntries;
 }

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesToolTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/adapter/in/mcp/ChallengesToolTest.java
@@ -28,15 +28,24 @@ class ChallengesToolTest {
     @Test
     void getChallengesByPlayer_passesPlatformAndPlayerThrough() {
         ChallengesPlayerData data = ChallengesPlayerData.builder().build();
-        when(mockService.getChallengesByPlayer(PLATFORM, "Faker#KR1")).thenReturn(data);
+        when(mockService.getChallengesByPlayer(PLATFORM, "Faker#KR1", null)).thenReturn(data);
 
-        assertThat(tool.getChallengesByPlayer("NA1", "Faker#KR1")).isSameAs(data);
-        verify(mockService).getChallengesByPlayer(PLATFORM, "Faker#KR1");
+        assertThat(tool.getChallengesByPlayer("NA1", "Faker#KR1", null)).isSameAs(data);
+        verify(mockService).getChallengesByPlayer(PLATFORM, "Faker#KR1", null);
+    }
+
+    @Test
+    void getChallengesByPlayer_passesCountThrough() {
+        ChallengesPlayerData data = ChallengesPlayerData.builder().build();
+        when(mockService.getChallengesByPlayer(PLATFORM, "Faker#KR1", 5)).thenReturn(data);
+
+        assertThat(tool.getChallengesByPlayer("NA1", "Faker#KR1", 5)).isSameAs(data);
+        verify(mockService).getChallengesByPlayer(PLATFORM, "Faker#KR1", 5);
     }
 
     @Test
     void getChallengesByPlayer_invalidPlatform_throws() {
-        assertThatThrownBy(() -> tool.getChallengesByPlayer("INVALID", "Faker#KR1"))
+        assertThatThrownBy(() -> tool.getChallengesByPlayer("INVALID", "Faker#KR1", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No enum constant");
     }

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/application/ChallengesServiceTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/challenges/application/ChallengesServiceTest.java
@@ -7,7 +7,11 @@ import static org.mockito.Mockito.when;
 import com.muddl.riot.account.identity.PlayerIdentityResolver;
 import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.lol.challenges.domain.ChallengePoints;
+import com.muddl.riot.lol.challenges.domain.ChallengeProgress;
 import com.muddl.riot.lol.challenges.domain.ChallengesPlayerData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class ChallengesServiceTest {
@@ -18,14 +22,95 @@ class ChallengesServiceTest {
     private final PlayerIdentityResolver resolver = mock(PlayerIdentityResolver.class);
     private final ChallengesService service = new ChallengesService(port, resolver);
 
-    @Test
-    void getChallengesByPlayer_resolvesPlayer_thenReturnsData() {
-        when(resolver.resolvePuuid("Faker#KR1")).thenReturn("faker-puuid");
-        ChallengesPlayerData data = ChallengesPlayerData.builder()
-                .totalPoints(ChallengePoints.builder().level("GOLD").build())
+    private static ChallengesPlayerData dataWith(List<ChallengeProgress> challenges) {
+        return ChallengesPlayerData.builder()
+                .totalPoints(ChallengePoints.builder().level("DIAMOND").build())
+                .challenges(challenges)
                 .build();
-        port.put("faker-puuid", data);
+    }
 
-        assertThat(service.getChallengesByPlayer(PLATFORM, "Faker#KR1")).isSameAs(data);
+    private static List<ChallengeProgress> progressOf(int size) {
+        // percentile descending with index, so the *last* entries are the best —
+        // a service that slices without sorting will fail these tests.
+        return IntStream.range(0, size)
+                .mapToObj(i -> ChallengeProgress.builder()
+                        .challengeId((long) i)
+                        .percentile(1.0 - (i / (double) size))
+                        .build())
+                .toList();
+    }
+
+    @Test
+    void getChallengesByPlayer_capsAtTen_andKeepsSummary() {
+        when(resolver.resolvePuuid("Faker#KR1")).thenReturn("faker-puuid");
+        port.put("faker-puuid", dataWith(progressOf(500)));
+
+        ChallengesPlayerData result = service.getChallengesByPlayer(PLATFORM, "Faker#KR1", null);
+
+        assertThat(result.getChallenges()).hasSize(10);
+        assertThat(result.getTotalChallenges()).isEqualTo(500);
+        assertThat(result.getTotalPoints().getLevel()).isEqualTo("DIAMOND");
+    }
+
+    @Test
+    void getChallengesByPlayer_sortsByPercentileAscending() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 3).getChallenges())
+                .extracting(ChallengeProgress::getChallengeId)
+                .containsExactly(499L, 498L, 497L);
+    }
+
+    @Test
+    void getChallengesByPlayer_honoursExplicitCount() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 42).getChallenges())
+                .hasSize(42);
+    }
+
+    @Test
+    void getChallengesByPlayer_zeroOrNegativeCount_clampsToDefault() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", dataWith(progressOf(500)));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", 0).getChallenges())
+                .hasSize(10);
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", -9).getChallenges())
+                .hasSize(10);
+    }
+
+    @Test
+    void getChallengesByPlayer_nullPercentiles_sortLastWithoutThrowing() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        List<ChallengeProgress> mixed = new ArrayList<>();
+        mixed.add(ChallengeProgress.builder().challengeId(1L).percentile(null).build());
+        mixed.add(ChallengeProgress.builder().challengeId(2L).percentile(0.5).build());
+        mixed.add(ChallengeProgress.builder().challengeId(3L).percentile(0.01).build());
+        port.put("p", dataWith(mixed));
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "p", null).getChallenges())
+                .extracting(ChallengeProgress::getChallengeId)
+                .containsExactly(3L, 2L, 1L);
+    }
+
+    @Test
+    void getChallengesByPlayer_nullChallenges_yieldsEmptyListAndZeroTotal() {
+        when(resolver.resolvePuuid("p")).thenReturn("p");
+        port.put("p", ChallengesPlayerData.builder().build());
+
+        ChallengesPlayerData result = service.getChallengesByPlayer(PLATFORM, "p", null);
+
+        assertThat(result.getChallenges()).isEmpty();
+        assertThat(result.getTotalChallenges()).isZero();
+    }
+
+    @Test
+    void getChallengesByPlayer_nullData_returnsNull() {
+        when(resolver.resolvePuuid("unknown")).thenReturn("unknown");
+
+        assertThat(service.getChallengesByPlayer(PLATFORM, "unknown", null)).isNull();
     }
 }

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueToolTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/league/adapter/in/mcp/LeagueToolTest.java
@@ -41,26 +41,37 @@ class LeagueToolTest {
     @Test
     void getApexLeague_defaultsQueue_whenNull() {
         LeagueList league = LeagueList.builder().tier("CHALLENGER").build();
-        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5"))
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null))
                 .thenReturn(league);
 
-        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null)).isSameAs(league);
-        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5");
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null, null)).isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
     }
 
     @Test
     void getApexLeague_honoursExplicitQueue() {
         LeagueList league = LeagueList.builder().tier("MASTER").build();
-        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR"))
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR", null))
                 .thenReturn(league);
 
-        assertThat(leagueTool.getApexLeague("NA1", "master", "RANKED_FLEX_SR")).isSameAs(league);
-        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR");
+        assertThat(leagueTool.getApexLeague("NA1", "master", "RANKED_FLEX_SR", null))
+                .isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_FLEX_SR", null);
+    }
+
+    @Test
+    void getApexLeague_passesCountThrough() {
+        LeagueList league = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3))
+                .thenReturn(league);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null, 3)).isSameAs(league);
+        verify(mockLeagueService).getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3);
     }
 
     @Test
     void getApexLeague_invalidTier_throws() {
-        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "DIAMOND", null))
+        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "DIAMOND", null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No enum constant");
     }

--- a/lol-mcp-server/src/test/java/com/muddl/riot/lol/league/application/LeagueServiceTest.java
+++ b/lol-mcp-server/src/test/java/com/muddl/riot/lol/league/application/LeagueServiceTest.java
@@ -8,8 +8,10 @@ import com.muddl.riot.account.identity.PlayerIdentityResolver;
 import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.lol.league.domain.ApexTier;
 import com.muddl.riot.lol.league.domain.LeagueEntry;
+import com.muddl.riot.lol.league.domain.LeagueItem;
 import com.muddl.riot.lol.league.domain.LeagueList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class LeagueServiceTest {
@@ -43,12 +45,91 @@ class LeagueServiceTest {
                 .isEmpty();
     }
 
-    @Test
-    void getApexLeague_delegatesToPort() {
-        LeagueList expected = LeagueList.builder().tier("CHALLENGER").build();
-        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", expected);
+    private static LeagueList ladderOf(int size) {
+        // leaguePoints ascending with index, so the *last* entries are the top ones —
+        // a service that slices without sorting will fail these tests.
+        return LeagueList.builder()
+                .tier("CHALLENGER")
+                .queue("RANKED_SOLO_5x5")
+                .entries(IntStream.range(0, size)
+                        .mapToObj(i -> LeagueItem.builder()
+                                .puuid("puuid-" + i)
+                                .leaguePoints(i)
+                                .build())
+                        .toList())
+                .build();
+    }
 
-        assertThat(leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5"))
-                .isSameAs(expected);
+    @Test
+    void getApexLeague_capsAtTen_whenCountIsNull() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
+
+        assertThat(result.getEntries()).hasSize(10);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+        assertThat(result.getTier()).isEqualTo("CHALLENGER");
+    }
+
+    @Test
+    void getApexLeague_sortsByLeaguePointsDescending() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 3);
+
+        assertThat(result.getEntries()).extracting(LeagueItem::getLeaguePoints).containsExactly(299, 298, 297);
+    }
+
+    @Test
+    void getApexLeague_honoursExplicitCount() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 50)
+                        .getEntries())
+                .hasSize(50);
+    }
+
+    @Test
+    void getApexLeague_countExceedingSize_returnsEverything() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(7));
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 5000);
+
+        assertThat(result.getEntries()).hasSize(7);
+        assertThat(result.getTotalEntries()).isEqualTo(7);
+    }
+
+    @Test
+    void getApexLeague_zeroOrNegativeCount_clampsToDefault() {
+        leaguePort.putApex(ApexTier.CHALLENGER, "RANKED_SOLO_5x5", ladderOf(300));
+
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", 0)
+                        .getEntries())
+                .hasSize(10);
+        assertThat(leagueService
+                        .getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", -4)
+                        .getEntries())
+                .hasSize(10);
+    }
+
+    @Test
+    void getApexLeague_nullEntries_yieldsEmptyListAndZeroTotal() {
+        leaguePort.putApex(
+                ApexTier.CHALLENGER,
+                "RANKED_SOLO_5x5",
+                LeagueList.builder().tier("CHALLENGER").build());
+
+        LeagueList result = leagueService.getApexLeague(PLATFORM, ApexTier.CHALLENGER, "RANKED_SOLO_5x5", null);
+
+        assertThat(result.getEntries()).isEmpty();
+        assertThat(result.getTotalEntries()).isZero();
+    }
+
+    @Test
+    void getApexLeague_nullLeague_returnsNull() {
+        assertThat(leagueService.getApexLeague(PLATFORM, ApexTier.MASTER, "RANKED_SOLO_5x5", null))
+                .isNull();
     }
 }

--- a/tft-mcp-server/CHANGELOG.md
+++ b/tft-mcp-server/CHANGELOG.md
@@ -6,6 +6,20 @@ Scoped to this module. Repo-wide changes live in the [root CHANGELOG](../CHANGEL
 libraries keep their own. Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/);
 versioning: [SemVer](https://semver.org/spec/v2.0.0.html), pre-1.0 (breaking → minor).
 
+## [0.2.0] - unreleased
+
+Live-eval token cost reduction, mirroring the `lol-mcp-server` change. See
+[the design spec](../docs/superpowers/specs/2026-07-23-live-eval-token-cost-design.md) and
+[ADR-0016](../docs/knowledge/decisions/ADR-0016-bounded-list-results.md).
+
+### Changed
+- **Breaking:** `tft_league_apex_by_tier` now returns only the **top 10 entries by league points**
+  by default (previously the entire apex ladder). An optional `count` param requests more; the
+  response now stamps `totalEntries` with the pre-truncation ladder size.
+- `tft_league_by_id` now stamps `totalEntries` with its entry count, for response-shape consistency
+  with the apex tools. It remains deliberately **unbounded and unsorted** — no `count` param, no
+  reordering.
+
 ## [0.1.0] - 2026-07-20
 
 Sub-project 2 — the first `tft-mcp-server` release, and the program's first proof that

--- a/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueTool.java
+++ b/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueTool.java
@@ -37,15 +37,20 @@ public class LeagueTool {
 
     @McpTool(
             name = "tft_league_apex_by_tier",
-            description = "Get a Teamfight Tactics apex league: CHALLENGER, GRANDMASTER, or MASTER.")
+            description =
+                    "Get a Teamfight Tactics apex league: CHALLENGER, GRANDMASTER, or MASTER. Returns the top 10 entries by league points unless a larger count is requested.")
     public LeagueList getApexLeague(
             @McpToolParam(description = "The Riot platform, e.g. NA1, EUW1", required = true) String platformStr,
             @McpToolParam(description = "The apex tier: CHALLENGER, GRANDMASTER, or MASTER", required = true)
-                    String tierStr) {
+                    String tierStr,
+            @McpToolParam(
+                            description = "Optional: return only the top N entries by league points; defaults to 10",
+                            required = false)
+                    Integer count) {
         RiotApiPlatformUri platform = RiotApiPlatformUri.valueOf(platformStr.toUpperCase());
         ApexTier tier = ApexTier.valueOf(tierStr.toUpperCase());
         log.info("MCP Tool - Getting TFT {} apex league on platform: {}", tier, platform);
-        return leagueService.getApexLeague(platform, tier);
+        return leagueService.getApexLeague(platform, tier, count);
     }
 
     @McpTool(

--- a/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/application/LeagueService.java
+++ b/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/application/LeagueService.java
@@ -5,8 +5,10 @@ import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.tft.league.application.port.LeaguePort;
 import com.muddl.riot.tft.league.domain.ApexTier;
 import com.muddl.riot.tft.league.domain.LeagueEntry;
+import com.muddl.riot.tft.league.domain.LeagueItem;
 import com.muddl.riot.tft.league.domain.LeagueList;
 import com.muddl.riot.tft.league.domain.RatedLadderEntry;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LeagueService {
 
+    /** Default number of apex entries returned when the caller does not specify a count. */
+    private static final int DEFAULT_APEX_ENTRIES = 10;
+
     private final LeaguePort leaguePort;
     private final PlayerIdentityResolver identityResolver;
 
@@ -27,9 +32,10 @@ public class LeagueService {
         return leaguePort.getLeagueEntriesByPuuid(platform, puuid);
     }
 
-    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier) {
+    public LeagueList getApexLeague(RiotApiPlatformUri platform, ApexTier tier, Integer count) {
         log.info("Fetching TFT {} apex league on platform: {}", tier, platform);
-        return leaguePort.getApexLeague(platform, tier);
+        int limit = (count == null || count <= 0) ? DEFAULT_APEX_ENTRIES : count;
+        return boundEntries(leaguePort.getApexLeague(platform, tier), limit);
     }
 
     public List<LeagueEntry> getEntriesByTier(RiotApiPlatformUri platform, String tier, String division, int page) {
@@ -39,7 +45,44 @@ public class LeagueService {
 
     public LeagueList getLeagueById(RiotApiPlatformUri platform, String leagueId) {
         log.info("Fetching TFT league by id on platform: {}", platform);
-        return leaguePort.getLeagueById(platform, leagueId);
+        LeagueList league = leaguePort.getLeagueById(platform, leagueId);
+        if (league == null) {
+            return null;
+        }
+        // Stamp the total for consistency with the apex response, but neither slice nor reorder:
+        // tft_league_by_id is deliberately out of scope for the bound (ADR-0016).
+        return league.toBuilder()
+                .totalEntries(
+                        league.getEntries() == null ? 0 : league.getEntries().size())
+                .build();
+    }
+
+    /**
+     * Returns a copy of {@code league} holding only the top {@code limit} entries by league points,
+     * with {@code totalEntries} stamped to the pre-truncation size. Riot's TFT-League-V1 apex
+     * endpoint has no server-side count parameter, so the bound is applied here in the application
+     * layer; entries are sorted first because Riot does not guarantee order. See ADR-0016.
+     *
+     * <p>Unlike the LoL server's equivalent, {@code leaguePoints} here is a boxed {@link Integer}
+     * and Riot may omit it, so the comparator is null-safe (nulls sort last) rather than a
+     * {@code comparingInt}, which would unbox and throw.
+     */
+    private static LeagueList boundEntries(LeagueList league, int limit) {
+        if (league == null) {
+            return null;
+        }
+        List<LeagueItem> entries = league.getEntries();
+        if (entries == null) {
+            return league.toBuilder().entries(List.of()).totalEntries(0).build();
+        }
+        return league.toBuilder()
+                .entries(entries.stream()
+                        .sorted(Comparator.comparing(
+                                LeagueItem::getLeaguePoints, Comparator.nullsLast(Comparator.reverseOrder())))
+                        .limit(limit)
+                        .toList())
+                .totalEntries(entries.size())
+                .build();
     }
 
     public List<RatedLadderEntry> getRatedLadder(RiotApiPlatformUri platform, String queue) {

--- a/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/domain/LeagueList.java
+++ b/tft-mcp-server/src/main/java/com/muddl/riot/tft/league/domain/LeagueList.java
@@ -1,5 +1,6 @@
 package com.muddl.riot.tft.league.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -9,8 +10,11 @@ import lombok.NoArgsConstructor;
 
 /** A TFT apex league (challenger/grandmaster/master) or a league fetched by id (Riot TFT-League-V1). */
 @Data
-@Builder
-@NoArgsConstructor
+@Builder(toBuilder = true)
+// Forces bean-style deserialization: without it Jackson picks the Lombok all-args constructor as a
+// properties-based creator and maps the absent totalEntries to null, failing on the primitive. See
+// gotchas.md, "Adding a primitive field to an existing Riot-mapped DTO".
+@NoArgsConstructor(onConstructor_ = @JsonCreator)
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LeagueList {
@@ -19,4 +23,10 @@ public class LeagueList {
     private String name;
     private String queue;
     private List<LeagueItem> entries;
+
+    /**
+     * Total entries in the league before any {@code count} bound was applied. Lets a caller that
+     * received a capped {@link #entries} list still know the real ladder size.
+     */
+    private int totalEntries;
 }

--- a/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueToolTest.java
+++ b/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/adapter/in/mcp/LeagueToolTest.java
@@ -62,33 +62,43 @@ class LeagueToolTest {
     @Test
     void getApexLeague_passesPlatformAndTierThrough() {
         LeagueList list = LeagueList.builder().tier("CHALLENGER").build();
-        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER))
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, null))
                 .thenReturn(list);
 
-        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER")).isSameAs(list);
-        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER);
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", null)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, null);
     }
 
     @Test
     void getApexLeague_normalizesCaseForPlatformAndTier() {
         LeagueList list = LeagueList.builder().tier("MASTER").build();
-        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER))
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER, null))
                 .thenReturn(list);
 
-        assertThat(leagueTool.getApexLeague("na1", "master")).isSameAs(list);
-        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER);
+        assertThat(leagueTool.getApexLeague("na1", "master", null)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.MASTER, null);
+    }
+
+    @Test
+    void getApexLeague_passesCountThrough() {
+        LeagueList list = LeagueList.builder().tier("CHALLENGER").build();
+        when(mockLeagueService.getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, 3))
+                .thenReturn(list);
+
+        assertThat(leagueTool.getApexLeague("NA1", "CHALLENGER", 3)).isSameAs(list);
+        verify(mockLeagueService).getApexLeague(RiotApiPlatformUri.NA1, ApexTier.CHALLENGER, 3);
     }
 
     @Test
     void getApexLeague_invalidPlatform_throws() {
-        assertThatThrownBy(() -> leagueTool.getApexLeague("INVALID", "CHALLENGER"))
+        assertThatThrownBy(() -> leagueTool.getApexLeague("INVALID", "CHALLENGER", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No enum constant");
     }
 
     @Test
     void getApexLeague_invalidTier_throws() {
-        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "BRONZE"))
+        assertThatThrownBy(() -> leagueTool.getApexLeague("NA1", "BRONZE", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No enum constant");
     }

--- a/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/application/LeagueServiceTest.java
+++ b/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/application/LeagueServiceTest.java
@@ -93,6 +93,17 @@ class LeagueServiceTest {
     }
 
     @Test
+    void getApexLeague_nullEntries_yieldsEmptyListAndZeroTotal() {
+        port.putApex(
+                ApexTier.CHALLENGER, LeagueList.builder().tier("CHALLENGER").build());
+
+        LeagueList result = service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, null);
+
+        assertThat(result.getEntries()).isEmpty();
+        assertThat(result.getTotalEntries()).isZero();
+    }
+
+    @Test
     void getApexLeague_nullLeaguePoints_sortLastWithoutThrowing() {
         // TFT's LeagueItem.leaguePoints is a boxed Integer and Riot may omit it —
         // a comparingInt comparator would NPE here.
@@ -134,6 +145,16 @@ class LeagueServiceTest {
         assertThat(result.getTotalEntries()).isEqualTo(300);
         // Original ascending order is preserved — league-by-id is out of scope for the bound.
         assertThat(result.getEntries().get(0).getLeaguePoints()).isZero();
+    }
+
+    @Test
+    void getLeagueById_nullEntries_stampsZeroTotal() {
+        port.putLeague("league-uuid", LeagueList.builder().tier("CHALLENGER").build());
+
+        LeagueList result = service.getLeagueById(PLATFORM, "league-uuid");
+
+        assertThat(result.getEntries()).isNull();
+        assertThat(result.getTotalEntries()).isZero();
     }
 
     @Test

--- a/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/application/LeagueServiceTest.java
+++ b/tft-mcp-server/src/test/java/com/muddl/riot/tft/league/application/LeagueServiceTest.java
@@ -8,9 +8,12 @@ import com.muddl.riot.account.identity.PlayerIdentityResolver;
 import com.muddl.riot.core.enums.RiotApiPlatformUri;
 import com.muddl.riot.tft.league.domain.ApexTier;
 import com.muddl.riot.tft.league.domain.LeagueEntry;
+import com.muddl.riot.tft.league.domain.LeagueItem;
 import com.muddl.riot.tft.league.domain.LeagueList;
 import com.muddl.riot.tft.league.domain.RatedLadderEntry;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class LeagueServiceTest {
@@ -40,11 +43,75 @@ class LeagueServiceTest {
         assertThat(service.getLeagueEntriesByPlayer(PLATFORM, "raw")).isEmpty();
     }
 
+    private static LeagueList ladderOf(int size) {
+        return LeagueList.builder()
+                .tier("CHALLENGER")
+                .entries(IntStream.range(0, size)
+                        .mapToObj(i -> LeagueItem.builder()
+                                .puuid("puuid-" + i)
+                                .leaguePoints(i)
+                                .build())
+                        .toList())
+                .build();
+    }
+
     @Test
-    void getApexLeague_delegatesToPort() {
-        LeagueList expected = LeagueList.builder().tier("CHALLENGER").build();
-        port.putApex(ApexTier.CHALLENGER, expected);
-        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER)).isSameAs(expected);
+    void getApexLeague_capsAtTen_whenCountIsNull() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        LeagueList result = service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, null);
+
+        assertThat(result.getEntries()).hasSize(10);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+    }
+
+    @Test
+    void getApexLeague_sortsByLeaguePointsDescending() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 3).getEntries())
+                .extracting(LeagueItem::getLeaguePoints)
+                .containsExactly(299, 298, 297);
+    }
+
+    @Test
+    void getApexLeague_honoursExplicitCount() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 50).getEntries())
+                .hasSize(50);
+    }
+
+    @Test
+    void getApexLeague_zeroOrNegativeCount_clampsToDefault() {
+        port.putApex(ApexTier.CHALLENGER, ladderOf(300));
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, 0).getEntries())
+                .hasSize(10);
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, -1).getEntries())
+                .hasSize(10);
+    }
+
+    @Test
+    void getApexLeague_nullLeaguePoints_sortLastWithoutThrowing() {
+        // TFT's LeagueItem.leaguePoints is a boxed Integer and Riot may omit it —
+        // a comparingInt comparator would NPE here.
+        List<LeagueItem> mixed = new ArrayList<>();
+        mixed.add(LeagueItem.builder().puuid("no-lp").leaguePoints(null).build());
+        mixed.add(LeagueItem.builder().puuid("low").leaguePoints(100).build());
+        mixed.add(LeagueItem.builder().puuid("high").leaguePoints(900).build());
+        port.putApex(
+                ApexTier.CHALLENGER,
+                LeagueList.builder().tier("CHALLENGER").entries(mixed).build());
+
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.CHALLENGER, null).getEntries())
+                .extracting(LeagueItem::getPuuid)
+                .containsExactly("high", "low", "no-lp");
+    }
+
+    @Test
+    void getApexLeague_nullLeague_returnsNull() {
+        assertThat(service.getApexLeague(PLATFORM, ApexTier.MASTER, null)).isNull();
     }
 
     @Test
@@ -58,10 +125,20 @@ class LeagueServiceTest {
     }
 
     @Test
-    void getLeagueById_delegatesToPort() {
-        LeagueList expected = LeagueList.builder().leagueId("league-uuid").build();
-        port.putLeague("league-uuid", expected);
-        assertThat(service.getLeagueById(PLATFORM, "league-uuid")).isSameAs(expected);
+    void getLeagueById_stampsTotal_withoutTruncatingOrReordering() {
+        port.putLeague("league-uuid", ladderOf(300));
+
+        LeagueList result = service.getLeagueById(PLATFORM, "league-uuid");
+
+        assertThat(result.getEntries()).hasSize(300);
+        assertThat(result.getTotalEntries()).isEqualTo(300);
+        // Original ascending order is preserved — league-by-id is out of scope for the bound.
+        assertThat(result.getEntries().get(0).getLeaguePoints()).isZero();
+    }
+
+    @Test
+    void getLeagueById_nullLeague_returnsNull() {
+        assertThat(service.getLeagueById(PLATFORM, "missing")).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What and why

Live-eval dispatches cost ~$2.60 in Anthropic tokens each, because three MCP tools returned huge list payloads and both CI transport legs ran the identical 24-task suite. This branch bounds those payloads and scopes the `sse` leg, cutting the cost to **$0.3265 per dispatch** (measured, run [`30027872244`](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30027872244)).

## Changes

- **Three bounded tools** — `lol_league_apex_by_tier`, `tft_league_apex_by_tier`, and `lol_challenges_by_player` each gain an optional `count` param with a **default of 10**, truncating in the application service (Riot's League-V4 / TFT-League-V1 / Challenges-V1 endpoints have no server-side count param). Pre-truncation sizes exposed as `totalEntries` / `totalChallenges`, so a caller always knows a list was capped. Sort-then-slice, null-safe per each field's declared type. ⚠️ Behavior change to three published tools; names and existing param descriptions unchanged.
- **Transport-scoped CI** — `stdio` keeps the full suite; `sse` runs a 4-task transport smoke set (`eval/smoke.txt`: handshake, a round-trip per server, error propagation). The job summary names the scope so a green `sse` leg can't be misread as full coverage. Guarded against both an empty and a stale smoke set.
- **Eval rubric fixes** — the champion-mastery `count` is now asserted structurally (judge-free); its rubric no longer contradicts its singular-champion prompt; the apex rubric retargeted at `totalEntries`.
- **`eval/tools/report-cost.py`** — prices a run's agent-loop token usage at the real Haiku 4.5 rates (the report's own `cost_estimate` uses a ~$0.50/MTok fallback that understates by ~2×). Fixes the rate error only; LLM-judge calls are absent from the report and remain unmeasured.
- **Docs** — ADR-0016 (bounded list results), ADR-0017 (transport-scoped eval), two gotchas, pattern guide, changelogs.

## Measured results

| Criterion | Target | Measured |
|---|---|---|
| `stdio` input tokens | ≤ 300,000 | 252,266 (−80%) |
| `sse` input tokens | ≤ 30,000 | 20,825 (−98%) |
| Combined cost | ≤ $0.35 | **$0.3265** (from ~$2.60) |
| Mastery test | passes | passes |
| New failures | none | none |

`lol_league_apex_by_tier` fell from 17,932 to 638 average tokens per call. The one failing task, `test_champion_rotation`, hit Riot's "temporarily unavailable" — the same infra flake that failed it in the baseline, explicitly excluded by the spec's criteria.

## One open question for the reviewer

`lol_challenges_by_player` sorts by `percentile` ascending on the assumption that a **lower percentile means a rarer/stronger** achievement. No test or live eval can falsify that premise — if Riot's semantics are inverted, the tool returns a player's ten *weakest* challenges and everything still passes green. The tool description was reworded to state the mechanism (lowest-percentile-first) rather than assert "strongest", and the open question is recorded in ADR-0016 and gotchas.md. **Worth confirming against the Riot developer portal before this ships**; if it inverts, the fix is one comparator plus the description.

## Testing

- `./gradlew build` green (offline, key-free): compile, unit tests, ArchUnit, JaCoCo, Spotless.
- Live validation dispatched and measured (above). Not gating; `workflow_dispatch`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
