### PR TITLE
fix(ci): unbreak the weekly housekeeping PR and put it behind the review gate

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -72,6 +72,18 @@ jobs:
           BRANCH="chore/housekeeping-$STAMP"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # claude-code-action takes ownership of this repo's git credentials during its step: it
+          # deletes the `http.https://github.com/.extraheader` credential actions/checkout persisted,
+          # repoints `origin` at a URL embedding its own OIDC-derived GitHub App installation token,
+          # and then revokes that token (DELETE /installation/token) as the step ends. So by the time
+          # this step runs, `origin` carries a dead credential and checkout's fallback is gone —
+          # every push here died with "Invalid username or token" (exit 128). GH_TOKEN below only
+          # authenticates `gh`, never `git`. Re-point origin at this job's own GITHUB_TOKEN, which is
+          # valid for the life of the job and already has the `contents: write` scope the push needs.
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore: weekly housekeeping ($STAMP)" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -62,12 +62,26 @@ jobs:
       - name: Open a PR if the pass changed anything
         if: steps.gate.outputs.proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT, deliberately not GITHUB_TOKEN. GitHub does not fire `pull_request` events for a
+          # PR opened with GITHUB_TOKEN (recursion guard), so such a PR gets NO ci.yml run and NO
+          # claude-code-review.yml run — it would sit there looking reviewable while nothing had
+          # reviewed it. ADR-0015 says this pass opens a PR "never merging unreviewed"; honouring
+          # that means the PR must be authored by a non-Actions identity. See ADR-0018.
+          GH_TOKEN: ${{ secrets.HOUSEKEEPING_TOKEN }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             echo "::notice title=Housekeeping::No changes to propose."
             exit 0
           fi
+
+          # Fail loudly rather than falling back to GITHUB_TOKEN: a silent fallback would still open
+          # a PR, but one that CI and the reviewer never see — the exact failure this design exists
+          # to prevent, and invisible precisely because the PR looks normal.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error title=Housekeeping::HOUSEKEEPING_TOKEN secret is not set. Refusing to open a PR with GITHUB_TOKEN, which would skip CI and Claude Code Review. Create a fine-grained PAT (Contents: read/write, Pull requests: read/write) and add it as the HOUSEKEEPING_TOKEN repository secret."
+            exit 1
+          fi
+
           STAMP="$(date -u +%Y-W%V)"
           BRANCH="chore/housekeeping-$STAMP"
           git config user.name  "github-actions[bot]"
@@ -78,9 +92,9 @@ jobs:
           # repoints `origin` at a URL embedding its own OIDC-derived GitHub App installation token,
           # and then revokes that token (DELETE /installation/token) as the step ends. So by the time
           # this step runs, `origin` carries a dead credential and checkout's fallback is gone —
-          # every push here died with "Invalid username or token" (exit 128). GH_TOKEN below only
-          # authenticates `gh`, never `git`. Re-point origin at this job's own GITHUB_TOKEN, which is
-          # valid for the life of the job and already has the `contents: write` scope the push needs.
+          # every push here died with "Invalid username or token" (exit 128). Setting GH_TOKEN does
+          # not help on its own: it authenticates `gh`, never `git`. Re-point origin at the PAT so
+          # both the push and the `gh pr create` below run as the same non-Actions identity.
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -83,7 +83,15 @@ jobs:
           fi
 
           STAMP="$(date -u +%Y-W%V)"
+          # Keyed to the ISO week only. A second run in the same week — workflow_dispatch bypasses
+          # the commit gate and always proceeds — collides with the existing branch and fails at
+          # `git push` or `gh pr create`. Deliberately left to fail loudly rather than silently
+          # opening a second PR for the same week; see gotchas.md.
           BRANCH="chore/housekeeping-$STAMP"
+
+          # The commit is authored by github-actions[bot] while the push and `gh pr create` below
+          # run as the PAT's identity, so the commit author and the PR's "opened by" differ on
+          # purpose: event delivery keys off the credential, not the commit trailer (ADR-0018).
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -93,15 +101,21 @@ jobs:
           # and then revokes that token (DELETE /installation/token) as the step ends. So by the time
           # this step runs, `origin` carries a dead credential and checkout's fallback is gone —
           # every push here died with "Invalid username or token" (exit 128). Setting GH_TOKEN does
-          # not help on its own: it authenticates `gh`, never `git`. Re-point origin at the PAT so
-          # both the push and the `gh pr create` below run as the same non-Actions identity.
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # not help on its own: it authenticates `gh`, never `git`.
+          #
+          # Restore a clean origin, then pass the PAT as a one-shot header on the push itself. An
+          # embedded `https://x-access-token:$TOKEN@...` remote would work too, but persists the
+          # token in .git/config for the rest of the job; `actions/checkout` avoids exactly that by
+          # using an extraheader, and this step — which exists to route around a credential footgun
+          # — should hold the same bar. The URL must be credential-free or its dead inline token
+          # would still be preferred over the header.
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
 
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore: weekly housekeeping ($STAMP)" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
-          git push -u origin "$BRANCH"
+          git -c http.https://github.com/.extraheader="$AUTH_HEADER" push -u origin "$BRANCH"
           gh pr create \
             --title "chore: weekly housekeeping ($STAMP)" \
             --body "Automated housekeeping pass (docs / KB / roadmap / skills / agents). Review the diff before merging." \

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -109,13 +109,15 @@ jobs:
           # using an extraheader, and this step — which exists to route around a credential footgun
           # — should hold the same bar. The URL must be credential-free or its dead inline token
           # would still be preferred over the header.
-          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # GITHUB_SERVER_URL rather than a literal github.com, and the extraheader config key is
+          # derived from the same value so host and key cannot drift apart.
+          git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
           AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
 
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore: weekly housekeeping ($STAMP)" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
-          git -c http.https://github.com/.extraheader="$AUTH_HEADER" push -u origin "$BRANCH"
+          git -c http."${GITHUB_SERVER_URL}/".extraheader="$AUTH_HEADER" push -u origin "$BRANCH"
           gh pr create \
             --title "chore: weekly housekeeping ($STAMP)" \
             --body "Automated housekeeping pass (docs / KB / roadmap / skills / agents). Review the diff before merging." \

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -37,6 +37,7 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [ADR-0015 — Repository maintenance automation](decisions/ADR-0015-repo-maintenance-automation.md)
 - [ADR-0016 — Bounded list results for MCP tools](decisions/ADR-0016-bounded-list-results.md)
 - [ADR-0017 — Transport-scoped live eval coverage](decisions/ADR-0017-transport-scoped-live-eval.md)
+- [ADR-0018 — Automated PRs are authored by a non-Actions identity so the review gate applies](decisions/ADR-0018-housekeeping-pr-review-gate.md)
 
 ### Patterns
 

--- a/docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md
+++ b/docs/knowledge/decisions/ADR-0015-repo-maintenance-automation.md
@@ -1,7 +1,13 @@
 # ADR-0015 — Repository maintenance automation
 
-- **Status:** Accepted
+- **Status:** Accepted (amended by [ADR-0018](ADR-0018-housekeeping-pr-review-gate.md))
 - **Date:** 2026-07-19
+
+> **Amendment (2026-08-01):** the "opens a PR — never merging unreviewed" clause below was not
+> actually enforced. The PR was opened with `GITHUB_TOKEN`, for which GitHub fires no
+> `pull_request` event, so it received neither CI nor Claude Code Review.
+> [ADR-0018](ADR-0018-housekeeping-pr-review-gate.md) moves PR authorship to a PAT so the gate
+> applies.
 
 ## Context
 

--- a/docs/knowledge/decisions/ADR-0018-housekeeping-pr-review-gate.md
+++ b/docs/knowledge/decisions/ADR-0018-housekeeping-pr-review-gate.md
@@ -1,0 +1,66 @@
+# ADR-0018 — Automated PRs are authored by a non-Actions identity so the review gate applies
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+- **Amends:** [ADR-0015](ADR-0015-repo-maintenance-automation.md)
+
+## Context
+
+[ADR-0015](ADR-0015-repo-maintenance-automation.md) specified that the weekly housekeeping pass
+"opens a PR — never merging unreviewed." The implementation opened that PR with the automatic
+`GITHUB_TOKEN`, which does not deliver on the intent:
+
+- GitHub deliberately does not fire `pull_request` / `push` events for refs and PRs created with
+  `GITHUB_TOKEN` (a recursion guard). So a housekeeping PR got **no `ci.yml` run and no
+  `claude-code-review.yml` run**. The PR existed and looked reviewable; nothing had reviewed it.
+- `claude-code-review.yml` additionally gates on actor type (`allowed_bots: 'dependabot'`), so even
+  a hypothetical event from `github-actions[bot]` would be refused.
+
+The intent was therefore unmet in a way that was invisible at a glance: the artifact ADR-0015 asked
+for (a PR) was present, while the property it wanted (review before merge) was absent. A green
+workflow run and an open PR both indicated success.
+
+This surfaced only after fixing an unrelated defect that had masked it — the PR step's `git push`
+had never once succeeded, because `claude-code-action` deletes the credential `actions/checkout`
+persists, repoints `origin` at its own installation token, and revokes that token when its step
+ends (see `gotchas.md`). Every run with changes to push died at the push, so the PR-creation path
+had never been reached.
+
+A repo-level setting ("Allow GitHub Actions to create and approve pull requests") makes
+`GITHUB_TOKEN` able to *create* the PR, and was briefly enabled here. It was rejected on reflection:
+it does not restore the missing `pull_request` event, so the PR still receives no CI and no review —
+and it grants every workflow in the repo the ability to approve pull requests, weakening the very
+gate it was invoked to support.
+
+## Decision
+
+**Any workflow-authored PR that is intended to be reviewed must be opened by a non-Actions
+identity.** For `housekeeping.yml` that is a fine-grained PAT stored as the `HOUSEKEEPING_TOKEN`
+repository secret, used for both the branch push and `gh pr create`, so the PR is authored by a
+human identity and receives the ordinary gate: `ci.yml` plus `claude-code-review.yml`.
+
+Supporting rules:
+
+- **Fail loudly, never fall back.** If `HOUSEKEEPING_TOKEN` is absent the step exits non-zero with
+  an actionable message. Falling back to `GITHUB_TOKEN` would still produce a PR — an unreviewed
+  one — reintroducing the original failure in its most deceptive form.
+- **Least privilege on the PAT.** Contents: read/write and Pull requests: read/write, scoped to this
+  repository only. Notably *not* Workflows: the housekeeping pass maintains docs, the KB, the
+  roadmap, skills, and agents, and must not be able to rewrite CI. A pass that needs to edit
+  `.github/workflows/` should fail and be done by hand.
+- **The repo-level Actions PR-creation setting stays off** (`can_approve_pull_request_reviews:
+  false`), so no workflow can create or approve PRs on its own authority.
+
+## Consequences
+
+- Housekeeping PRs are built and reviewed exactly like human PRs; ADR-0015's "never merging
+  unreviewed" is now enforced by mechanism rather than asserted by intent.
+- A PAT is a credential with an expiry and a human owner — an operational cost this repo did not
+  previously carry. When it expires the pass fails loudly at the guard, which is the intended
+  behaviour, not a regression to debug.
+- The pattern generalizes: any future automation opening a PR for review (the GitHub Issues →
+  superpowers → review cycle on the roadmap) inherits this rule and this secret rather than
+  rediscovering the problem.
+- A GitHub App (via `actions/create-github-app-token`) would remove the expiry and narrow the
+  blast radius further. Deferred, not rejected — it is the natural upgrade once more than one
+  workflow needs an authoring identity.

--- a/docs/knowledge/decisions/ADR-0018-housekeeping-pr-review-gate.md
+++ b/docs/knowledge/decisions/ADR-0018-housekeeping-pr-review-gate.md
@@ -64,3 +64,10 @@ Supporting rules:
 - A GitHub App (via `actions/create-github-app-token`) would remove the expiry and narrow the
   blast radius further. Deferred, not rejected — it is the natural upgrade once more than one
   workflow needs an authoring identity.
+- **Known leftover scope, deliberately not trimmed.** The job still grants the ambient
+  `GITHUB_TOKEN` `contents: write` and `pull-requests: write`, which nothing uses any more: the push
+  and `gh pr create` both authenticate with the PAT, and `actions/checkout` needs only read. It is
+  left in place because `claude-code-action` refuses to run when the workflow file differs from the
+  default branch, so **no permissions change can be validated before merging it** — a wrong trim
+  would surface only on the next scheduled run, silently. Trim it in a standalone PR where a
+  post-merge dispatch can verify the pass still runs.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -244,6 +244,13 @@ opened using the automatic `GITHUB_TOKEN` (to prevent recursive runs). So the we
 `claude-code-review.yml` run. That is expected, not a bug. If auto-review on those PRs is ever
 wanted, open them with a PAT or GitHub App token instead of `GITHUB_TOKEN`.
 
+Separately, `GITHUB_TOKEN` cannot open a PR at all unless the repo-level **"Allow GitHub Actions to
+create and approve pull requests"** setting is on — `pull-requests: write` in the workflow is
+necessary but not sufficient. With it off, `gh pr create` fails with `GraphQL: GitHub Actions is not
+permitted to create or approve pull requests (createPullRequest)`. It was enabled for this repo on
+2026-08-01 so `housekeeping.yml` could open its PR. Check it with
+`gh api repos/<owner>/<repo>/actions/permissions/workflow` (`can_approve_pull_request_reviews`).
+
 ## A merge to `master` can occasionally trigger no Actions runs (dropped push event)
 
 GitHub Actions very occasionally **drops the `push` event** for a merge to the default branch even
@@ -309,3 +316,37 @@ silently returns the player's ten *weakest* challenges instead, and every existi
 — this is not something offline tests can catch, only a live response or the portal docs can settle
 it. If you resolve this, the fix (if needed) is a one-line comparator direction change plus updating
 `ChallengesTool`'s description; no architectural change. See ADR-0016's ordering section.
+
+## `claude-code-action` revokes the git credentials any later step in the job needs
+
+The action takes ownership of the repo's git auth for the duration of its step: it deletes the
+`http.https://github.com/.extraheader` credential `actions/checkout` persisted, repoints `origin` at
+a URL embedding its own OIDC-derived GitHub App installation token — and then **revokes that token**
+(`DELETE /installation/token`) as the step ends. Any later step in the same job that runs `git push`
+therefore pushes with a dead credential and no fallback, failing with
+`remote: Invalid username or token` / `fatal: Authentication failed` / exit 128. Setting `GH_TOKEN`
+on that step does not help: it authenticates `gh`, never `git`. This broke every `housekeeping.yml`
+run that had changes to push. The fix is to re-establish a credential immediately before the push:
+
+```bash
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+```
+
+Any future workflow that runs `claude-code-action` and then does its own git write needs the same
+line — the action leaves the repo unauthenticated on the way out.
+
+## `claude-code-action` is silently skipped when the workflow file differs from the default branch
+
+The action hard-requires the workflow file to be **byte-identical to the copy on the default
+branch**; dispatched from a branch with any edit to that file, it skips itself with
+`Skipping action due to workflow validation: Workflow validation failed` — an *annotation*, not a
+failure. The job goes green having done nothing. This makes branch-based validation of any workflow
+containing the action vacuously green, and it is a trap in two directions: a run can also look
+"successful" merely because the pass produced no diff and the later steps short-circuited (the
+2026-07-19 housekeeping run passed for exactly that reason while the push path was fully broken).
+
+To validate the *non-Claude* steps of such a workflow from a branch, replace the action with a step
+that replays the state it leaves behind — unset the extraheader and point `origin` at a bogus token
+— then run the real steps against it. That reproduces the post-action condition exactly, costs no
+Claude tokens, and finishes in seconds. Always confirm the step you meant to test actually ran;
+`conclusion: success` on a workflow gated by `if:` and early `exit 0`s proves very little.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -356,3 +356,16 @@ that replays the state it leaves behind — unset the extraheader and point `ori
 — then run the real steps against it. That reproduces the post-action condition exactly, costs no
 Claude tokens, and finishes in seconds. Always confirm the step you meant to test actually ran;
 `conclusion: success` on a workflow gated by `if:` and early `exit 0`s proves very little.
+
+## The housekeeping branch name is keyed to the ISO week, so a second run in one week collides
+
+`housekeeping.yml` derives its branch from `date -u +%Y-W%V` (`chore/housekeeping-2026-W31`), and
+`workflow_dispatch` deliberately bypasses the commit gate and always proceeds. So a manual dispatch
+in the same week as the scheduled Monday run — or two manual dispatches — targets a branch that
+already exists on the remote: `git push` fails non-fast-forward, or `gh pr create` fails with "a
+pull request already exists". This was unreachable while the push was broken (see the
+credential-handover gotcha above) and became reachable the moment it was fixed.
+
+Left to fail loudly on purpose. The alternative — a run-id suffix — would silently open a second PR
+proposing the same week's maintenance, and two competing housekeeping PRs is a worse failure than a
+red run. If you need to re-run a week, delete the existing branch and its PR first.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -244,12 +244,18 @@ opened using the automatic `GITHUB_TOKEN` (to prevent recursive runs). So the we
 `claude-code-review.yml` run. That is expected, not a bug. If auto-review on those PRs is ever
 wanted, open them with a PAT or GitHub App token instead of `GITHUB_TOKEN`.
 
-Separately, `GITHUB_TOKEN` cannot open a PR at all unless the repo-level **"Allow GitHub Actions to
-create and approve pull requests"** setting is on — `pull-requests: write` in the workflow is
+Separately, `GITHUB_TOKEN` cannot open a PR **at all** unless the repo-level **"Allow GitHub Actions
+to create and approve pull requests"** setting is on — `pull-requests: write` in the workflow is
 necessary but not sufficient. With it off, `gh pr create` fails with `GraphQL: GitHub Actions is not
-permitted to create or approve pull requests (createPullRequest)`. It was enabled for this repo on
-2026-08-01 so `housekeeping.yml` could open its PR. Check it with
+permitted to create or approve pull requests (createPullRequest)`. Check it with
 `gh api repos/<owner>/<repo>/actions/permissions/workflow` (`can_approve_pull_request_reviews`).
+
+**Do not reach for that setting to fix a blocked `gh pr create`.** It was briefly enabled here on
+2026-08-01 and then reverted: it makes the PR creatable but does nothing about the missing
+`pull_request` event, so the resulting PR still gets no CI and no review — it buys a PR that merely
+*looks* reviewable. It also grants every workflow in the repo the ability to approve PRs, which
+undercuts the review gate it was meant to serve. `housekeeping.yml` uses a PAT instead
+(`HOUSEKEEPING_TOKEN`); see [ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md).
 
 ## A merge to `master` can occasionally trigger no Actions runs (dropped push event)
 

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -153,9 +153,35 @@ you can verify output."* The bottleneck is verification, not authorship — a re
 repo's standing constraint that green tests do not prove the server serves. Every step below is
 judged on whether it strengthens verification, not on how much it automates.
 
+### The primitives, and which ones exist here
+
+Convergent-evolution argument from
+[the walkthrough](https://www.youtube.com/watch?v=lx0Eaane4Ng) (reference implementation:
+[Warren](https://app.warren.run)): independently, the companies doing this at scale have landed on
+the same handful of parts. Four in the main path — a **work queue**, a **control plane**, a
+**sandbox**, and a **handoff to a human** — over two substrate layers, an **event stream** and
+**durable memory**. Two framings there are worth stealing outright: work arrives as an *issue* that
+an agent is assigned, not as a hand-written prompt; and durable memory exists because the sandbox
+dies every run, so anything worth keeping must be git-tracked before the machine is destroyed.
+
+Auditing this repo against them — the gaps are intake and observability, not execution:
+
+| Primitive | State here |
+|---|---|
+| **Sandbox** — ephemeral, per-agent, destroyed after the task | ✅ A GitHub-hosted runner per run, discarded on completion. `--allowedTools` is the permission surface. |
+| **Durable memory** — git-tracked, survives the sandbox | ✅ `docs/knowledge/` plus the hydrate/persist protocol. This repo's strongest primitive; it is already the thing the pattern asks for. |
+| **Handoff to a human** — the PR is the output unit | ✅ [ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md) made this real rather than nominal. |
+| **Control plane** — queue, orchestrate, observe | ◐ GitHub Actions is a thin one: schedule, dispatch, a concurrency group. No cross-run view of what agents did or where they fail. |
+| **Work queue** — issues, assigned | ⏳ Issues are not yet the intake path. This is the next real step. |
+| **Event stream** — traces to steer, pause, fork, and analyse in aggregate | ⏳ Weakest. Only Actions logs, and `claude-code-action` hides SDK output by default (`show_full_output`), so a run's reasoning is not inspectable after the fact. Without this there is no way to find *systematic* agent failure, only individual ones. |
+
+The near-term ambition is explicitly **not** a dark factory. The argument against it is not
+capability but maturity: a human review step at the end is what keeps the system legible to the
+people responsible for it, which matches this repo's premise that the discipline is the product.
+
 ### Substrate already in place
 
-The factory is mostly assembled; what is missing is intake and the loop-back, not the gates.
+Beyond the primitives, the quality gates the pattern depends on are largely built.
 
 | Factory component | Here today |
 |---|---|
@@ -176,8 +202,10 @@ Incremental; each step is useful alone, and none is scheduled against a game sub
 | Scheduled agent work opens a PR rather than committing | ✅ Shipped | `housekeeping.yml` ([ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md)). |
 | Agent-authored PRs actually receive CI + review | ✅ Shipped | [ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md). The `GITHUB_TOKEN` form opened PRs no workflow ever saw — the gate was intent, not mechanism. |
 | Issue → spec/plan → implementation, agent-driven | ⏳ Not started | The superpowers brainstorm → write-plan → execute-plan cycle from a labelled Issue. Spec quality is the control surface: vague inputs yield confident, wrong output. Needs a decision on where the plan artifact lives, since `docs/superpowers/plans/` is immutable history. |
-| Review findings loop back as commits on the same PR | ⏳ Not started | Closes the cycle. Needs a **hard iteration cap** (minions allow two CI rounds); an agent revising until the reviewer goes quiet optimizes for reviewer silence, not correctness. |
-| Branch protection encoding the gate | ⏳ Not started | Makes the loop enforceable rather than conventional: required checks, no self-approval. |
+| Full run traces retained and inspectable | ⏳ Not started | The event-stream primitive. Start cheap: `show_full_output` on the housekeeping action, then somewhere durable to put run records. Prerequisite for improving agents rather than just re-running them. |
+| Review findings loop back as commits on the same PR | ⏳ Not started | Closes the cycle, and needs **suspend/resume** — an agent that pauses for CI or for reviewer feedback and then continues, rather than one-shotting and exiting. Named as the notable gap in current implementations. Also needs a **hard iteration cap** (minions allow two CI rounds); an agent revising until the reviewer goes quiet optimizes for reviewer silence, not correctness. |
+| Distinct machine identity for automated PRs | ⏳ Not started | **Prerequisite for the row below.** See "Attribution" under the constraints. |
+| Branch protection encoding the gate | ⏳ Not started | Makes the loop enforceable rather than conventional: required checks, no self-approval. Blocked on the row above. |
 | Tiered autonomy by blast radius | ⏳ Not started | Docs/KB changes need less ceremony than a change to `RiotApiClient` or a tool contract. Progressive autonomy, earned per area. |
 
 ### Failure modes to design against
@@ -194,6 +222,30 @@ treating them as design constraints rather than hypotheticals:
   reached ([ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md)).
 - **Velocity theater.** Throughput is not a goal here; this repo's value is the discipline, so
   cycle-time metrics stay subordinate to the gates.
+
+### Attribution: automated PRs currently author as a human
+
+`HOUSEKEEPING_TOKEN` is a fine-grained PAT, and a PAT *acts as the person who owns it*. So the
+housekeeping PR is authored by `Muddl` — not because a human triggered that run, but inherently: the
+unattended Monday run will attribute itself the same way. Two costs, one of which is blocking:
+
+- **Provenance.** Machine-authored work is recorded as a person's, which muddies exactly the
+  replayability and event-stream properties this track is trying to build. "Who wrote this?" stops
+  being answerable from the PR.
+- **It blocks branch protection.** GitHub does not let the author of a PR approve it. Under a
+  required-approvals rule, a housekeeping PR authored by the repo's only human maintainer can never
+  be approved by them — the gate becomes unsatisfiable rather than merely inconvenient.
+
+The fix is a **GitHub App identity** (`actions/create-github-app-token`) rather than a PAT: App
+installation tokens *do* trigger `pull_request` events — unlike `GITHUB_TOKEN`, which is what
+[ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md) rejected — so the review gate survives
+the move, while authorship lands on a bot actor distinct from any human. It also retires the PAT's
+expiry.
+
+**Carry this forward when doing it:** `claude-code-review.yml` gates on actor type
+(`allowed_bots: 'dependabot'`). An App-authored PR arrives as that App's bot and will be **refused
+by the reviewer unless the App is added to `allowed_bots`** — silently, with a green run, which is
+precisely the failure class ADR-0018 exists to prevent. Change both files in the same commit.
 
 **Standing constraint for this track:** automation may *propose* but never *approve*. The repo-level
 "Allow GitHub Actions to create and approve pull requests" setting stays off, and no workflow holds

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -247,6 +247,21 @@ expiry.
 by the reviewer unless the App is added to `allowed_bots`** — silently, with a green run, which is
 precisely the failure class ADR-0018 exists to prevent. Change both files in the same commit.
 
+### Review-cycle cap: two revision rounds per PR
+
+A PR in this flow gets **at most two rounds of acting on reviewer findings**. After the second
+round, it merges as long as what remains is non-blocking; leftover suggestions are filed as
+follow-up issues rather than fixed in place. Mirrors the two-CI-round limit minions uses.
+
+- **Blocking findings are exempt.** Correctness, security, and "this would break on merge" are fixed
+  regardless of round count. The cap bounds polish, never soundness.
+- **Why:** reviewer findings have sharply diminishing returns — round one catches real defects, round
+  three suggests comment rewording. An unbounded revise-until-the-reviewer-is-silent loop spends
+  usage chasing asymptotic perfection, and optimizes for reviewer silence rather than correctness.
+  Each round also costs a full review run.
+- This is the same stop condition the automated loop-back step above will need; applying it to
+  human-triggered PRs now means the rule is established before it is automated.
+
 **Standing constraint for this track:** automation may *propose* but never *approve*. The repo-level
 "Allow GitHub Actions to create and approve pull requests" setting stays off, and no workflow holds
 an identity that can approve its own work ([ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md)).

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -127,6 +127,78 @@ key.
 Smallest surface. **Verify LoR is not in maintenance before investing.** Parts of it need a
 production key, and deck endpoints need Bearer/RSO auth, which `RiotApiClient` does not support.
 
+## Cross-cutting: the software factory ⏳
+
+A second track, orthogonal to the per-game sub-projects above. Those grow *what the repo does*; this
+grows *how change reaches `master`*.
+
+The reference model is Cole Murray's [software factory](https://murraycole.com/posts/software-factory)
+— *"a repeatable system for turning defined work into production software through standardized
+inputs, shared tooling, automated quality gates, and measurable output"* — with agents planning,
+implementing, testing, and reviewing while humans set intent and acceptance criteria. Its loop is
+**signal → intake → context → plan → build → test and review → deploy → monitor → learn**, and the
+role shift is from being *in* the loop to *on* it. Stripe's
+[minions](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents.md)
+([part 2](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents-part-2.md)) are
+the same shape at scale: unattended agents in isolated devboxes, an agent loop **interleaved with
+deterministic steps** for git, lint, and test, hard iteration limits, and human review before every
+merge.
+
+Local target loop: **GitHub Issue → superpowers-driven development → Claude Code Review → merge.**
+
+### The governing constraint
+
+*"Generation is cheap and getting cheaper, so your ceiling is set by how fast and how trustworthily
+you can verify output."* The bottleneck is verification, not authorship — a restatement of this
+repo's standing constraint that green tests do not prove the server serves. Every step below is
+judged on whether it strengthens verification, not on how much it automates.
+
+### Substrate already in place
+
+The factory is mostly assembled; what is missing is intake and the loop-back, not the gates.
+
+| Factory component | Here today |
+|---|---|
+| Automated quality gates | `./gradlew build` — tests, ArchUnit, JaCoCo, Spotless — plus the post-merge live eval harness ([ADR-0012](decisions/ADR-0012-live-eval-harness.md)) |
+| Shared tooling | Agents run the same Gradle build and the same project skills a human runs; there is no agent-only path |
+| Standardized inputs | KB hydrate/persist protocol, project skills, `CLAUDE.md` |
+| Back-pressure before review | ArchUnit, Spotless, and the negative-control tests fail locally, pre-PR — Stripe's "shift feedback left" |
+| Measurable output | JaCoCo coverage; eval token cost via `eval/tools/report-cost.py` |
+| Replayability | ADRs + immutable `docs/superpowers/specs|plans/` record why a change looks the way it does |
+
+### Sequencing
+
+Incremental; each step is useful alone, and none is scheduled against a game sub-project.
+
+| Step | State | Notes |
+|---|---|---|
+| Reviewer posts real, reviewable feedback | ✅ Shipped | [ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md). Was green-but-silent before. |
+| Scheduled agent work opens a PR rather than committing | ✅ Shipped | `housekeeping.yml` ([ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md)). |
+| Agent-authored PRs actually receive CI + review | ✅ Shipped | [ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md). The `GITHUB_TOKEN` form opened PRs no workflow ever saw — the gate was intent, not mechanism. |
+| Issue → spec/plan → implementation, agent-driven | ⏳ Not started | The superpowers brainstorm → write-plan → execute-plan cycle from a labelled Issue. Spec quality is the control surface: vague inputs yield confident, wrong output. Needs a decision on where the plan artifact lives, since `docs/superpowers/plans/` is immutable history. |
+| Review findings loop back as commits on the same PR | ⏳ Not started | Closes the cycle. Needs a **hard iteration cap** (minions allow two CI rounds); an agent revising until the reviewer goes quiet optimizes for reviewer silence, not correctness. |
+| Branch protection encoding the gate | ⏳ Not started | Makes the loop enforceable rather than conventional: required checks, no self-approval. |
+| Tiered autonomy by blast radius | ⏳ Not started | Docs/KB changes need less ceremony than a change to `RiotApiClient` or a tool contract. Progressive autonomy, earned per area. |
+
+### Failure modes to design against
+
+Named in the sources, and **two are already evidenced in this repo** — which is the argument for
+treating them as design constraints rather than hypotheticals:
+
+- **Generation outpacing verification.** The reason the governing constraint above is first.
+- **Agents as lenient self-graders.** Observed 2026-08-01: a workflow validation run reported
+  `conclusion: success` while the step under test had silently skipped itself, and the "passing" run
+  proved nothing. See `gotchas.md`.
+- **Silent failure that looks like success.** Observed twice in the same incident — the 2026-07-19
+  housekeeping run went green only because the pass produced no diff and the broken push was never
+  reached ([ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md)).
+- **Velocity theater.** Throughput is not a goal here; this repo's value is the discipline, so
+  cycle-time metrics stay subordinate to the gates.
+
+**Standing constraint for this track:** automation may *propose* but never *approve*. The repo-level
+"Allow GitHub Actions to create and approve pull requests" setting stays off, and no workflow holds
+an identity that can approve its own work ([ADR-0018](decisions/ADR-0018-housekeeping-pr-review-gate.md)).
+
 ## Deferred, with a home
 
 Real and wanted, deliberately not scheduled. Recorded so they are not re-derived:


### PR DESCRIPTION
## What was broken

Two defects, one hiding behind the other.

**1. The push had never worked.** Runs [30265777135](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30265777135) (07-27) and [29739692386](https://github.com/Muddl/riot-api-mcp-server/actions/runs/29739692386) (07-20) both died with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/Muddl/riot-api-mcp-server.git/'
##[error]Process completed with exit code 128.
```

`claude-code-action` takes ownership of the repo's git credentials: it deletes the `extraheader` `actions/checkout` persists, repoints `origin` at its own OIDC-derived app token, then **revokes that token** (`DELETE /installation/token`) as its step ends. One second later the PR step pushes against a dead credential. `GH_TOKEN` authenticates `gh`, never `git`.

The one green run (07-19) passed only because the pass produced no diff and the step exited at `No changes to propose` before reaching the push.

**2. Even fixed, the PR would never have been reviewed.** GitHub fires no `pull_request` event for a PR opened with `GITHUB_TOKEN`, so the housekeeping PR would get **no `ci.yml` run and no `claude-code-review.yml` run**. `claude-code-review.yml` also gates on actor type (`allowed_bots: 'dependabot'`), which a bot author fails regardless. ADR-0015's *"opens a PR — never merging unreviewed"* was intent, not mechanism.

## The fix

- Re-point `origin` at a valid credential immediately before the push.
- Author both the push and `gh pr create` with a **PAT** (`HOUSEKEEPING_TOKEN`), so the PR comes from a non-Actions identity and takes the ordinary gate: CI + Claude Code Review.
- **Fail loudly** if the secret is missing rather than falling back to `GITHUB_TOKEN` — a fallback still opens a PR, just one nothing reviews.

I briefly enabled the repo-level *"Allow GitHub Actions to create and approve pull requests"* setting while diagnosing; it is **reverted** (`can_approve_pull_request_reviews: false`). It makes the PR creatable without restoring the missing event, and lets any workflow approve PRs — weakening the gate it was invoked to serve.

Job `permissions:` are deliberately untouched: `claude-code-action` cannot run from a branch, so a permissions trim could not be validated before merge.

## Verification

`claude-code-action` refuses to run when the workflow file differs from the default branch's copy, so a branch dispatch skips it and goes vacuously green. I instead replayed the exact post-action credential state and ran the real steps against it:

| Run | Config | Result |
|---|---|---|
| [30680978785](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30680978785) | repro, no fix | ❌ `Invalid username or token`, exit 128 — reproduces byte-for-byte |
| [30681000333](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30681000333) | + push fix | ✅ push succeeded; surfaced the PR-permission defect |
| [30681875105](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30681875105) | + PAT | ✅ pushed and opened PR #68 |

**Acceptance criterion met.** PR #68 — opened by the workflow via the PAT — resolved to author `Muddl` (not a bot) and triggered both workflows on `pull_request`: [CI](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30681881910) ✅ and [Claude Code Review](https://github.com/Muddl/riot-api-mcp-server/actions/runs/30681881896) ✅, with the reviewer posting a real summary **and** inline comments. That is the property the `GITHUB_TOKEN` design could not deliver.

The reviewer also caught a genuine mistake: the validation branch still carried the `SCRATCH` stand-in step, which would have permanently disabled housekeeping if merged. It was dropped; this PR contains the real `uses: anthropics/claude-code-action@v1` step and no scratch artifacts. Validation PRs #66 and #68 and their branches are cleaned up.

**Still unverified:** a full production run with Claude actually executing the housekeeping skill — impossible from a branch, since the action requires the workflow file to match `master`. First real test is the Monday schedule, or a manual dispatch after merge.

## Docs

- **ADR-0018** — automated PRs are authored by a non-Actions identity so the review gate applies; amends ADR-0015 (annotated).
- **`gotchas.md`** — the credential trap, the workflow-validation trap, and why not to reach for the repo setting.
- **`roadmap.md`** — new cross-cutting **software factory** track, grounded in [the walkthrough](https://www.youtube.com/watch?v=lx0Eaane4Ng), [Murray](https://murraycole.com/posts/software-factory), and [Stripe's minions](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents.md): verification as the governing constraint, an audit of this repo against the six primitives, sequencing, failure modes, and the **attribution gap** — a PAT acts as its owner, so unattended PRs author as a human, which blocks branch protection since GitHub forbids authors approving their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap