### PR TITLE
docs(factory): add the F0 and F2 implementation plans

### DIFF
--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -208,9 +208,9 @@ which also **corrects three claims this section previously made** (see below).
 
 | # | Sub-project | State | Notes |
 |---|---|---|---|
-| **F0** | Harden the gate | ⏳ Not started | Ruleset surgery, the fork-PR fix that must precede any required check, bounds/kill-switch/alerting, #71, and the stale-doc sweep. Ships **no new agent behaviour**, so it is the only sub-project fully verifiable before it is depended on. |
+| **F0** | Harden the gate | ⏳ Not started — [plan](../superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md) | Ruleset surgery, the fork-PR fix that must precede any required check, bounds/kill-switch/alerting, #71, and the stale-doc sweep. Ships **no new agent behaviour**, so it is the only sub-project fully verifiable before it is depended on. |
 | **F1** | Machine identity (GitHub App) | ⏳ Not started | Retires the PAT. Desk-only — a private key is not a phone artifact. |
-| **F2** | Issue intake, two-phase | ⏳ Not started | `agent:plan` commits a plan and posts its SHA; `agent:go` implements *that SHA*, checked by a deterministic `git diff --exit-code`. The work-queue primitive. |
+| **F2** | Issue intake, two-phase | ⏳ Not started — [plan](../superpowers/plans/2026-08-01-factory-f2-issue-intake.md) | `agent:plan` commits a plan and posts its SHA; `agent:go` implements *that SHA*, checked by a deterministic `git diff --exit-code`. The work-queue primitive. **Needs F0 first** — the current `~ALL` PR-required rule rejects `agent:go`'s second push to an existing branch. |
 | **F3** | Machine-emitted run traces | ⏳ Not started | The event stream, restricted to facts non-agent steps emit. Blocked on #71. |
 | **F4** | Review loop-back | ⏳ Not started | `agent:revise` label; two-round cap counted from the append-only issue timeline; enforced by a tool-less `gate` job. |
 | **F5** | Tiered autonomy by blast radius | ⏳ Not started | Docs/KB changes need less ceremony than a change to `RiotApiClient` or a tool contract. A CI check verifies changed paths against the declared tier; `file_path_restriction` push rules are org-only. |

--- a/docs/superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md
+++ b/docs/superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md
@@ -1,0 +1,1733 @@
+# Factory F0 — Harden the Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the merge gate mean something before anything depends on it — unblock fork PRs, pin `Build & verify` as a required status check on `master` via two rulesets with identical bypass, bound and kill-switch every agent job, add an alert path that reaches a phone, apply ruleset config from a script that never runs in CI, verify it with a scheduled drift check, close #71, and sweep the stale "post-merge live eval" claim.
+
+**Architecture:** Repository ruleset `8769144` is split — updated in place (PUT, id preserved) into **R1** (`~ALL`: `deletion`, `non_fast_forward`) and joined by a newly created **R2** (`~DEFAULT_BRANCH`: `pull_request{1 approval}`, `required_status_checks[Build & verify]`). Both carry the identical admin-`exempt` bypass so the undocumented cross-ruleset bypass question never arises. The desired state lives as committed JSON under `.github/rulesets/`; a local-only apply script (maintainer's own credential) writes it, and a read-only scheduled workflow diffs live against committed and fails loudly. Every `claude-code-action` job gains `timeout-minutes`, `if: vars.FACTORY_ENABLED == 'true'`, and an `if: failure()` step that `@Muddl`-mentions on an issue so GitHub Mobile pushes a notification.
+
+**Tech Stack:** GitHub Actions, GitHub repository rulesets API, `gh` CLI, `jq`, Bash, Markdown. No application (Java) code changes.
+
+## Global Constraints
+
+- **A green Actions run is not proof of success.** Three green-but-did-nothing incidents are on record in this repo (`gotchas.md`). Every task below asserts the *intended effect* — a check run named in a ruleset, a merge button that refuses, a drift check that goes red — never the job's exit status.
+- **Editing `claude-code-review.yml` or `claude.yml` means this PR will not be reviewed by Claude.** `claude-code-action` hard-requires the workflow file to be byte-identical to the default-branch copy; dispatched from a branch that edits it, the action **skips itself** with `Skipping action due to workflow validation` recorded as an *annotation on a successful job*. Tasks 3–5 edit both files, so expect no Claude review on the F0 PR. **State this in the PR body** (Task 9 Step 2) so it is not later misread as the reviewer silently failing. See `docs/knowledge/gotchas.md`, "`claude-code-action` is silently skipped when the workflow file differs from the default branch".
+- **`enforcement: "evaluate"` (ruleset dry-run) is "only available with GitHub Enterprise"** and does not exist on this free personal repo. Do not plan around it, do not add it to any JSON, do not suggest "try it in evaluate mode first".
+- **Automation may propose but never approve — and never rewrites the rules.** The apply script runs **locally, under the maintainer's own credential, never in CI**. A workflow able to rewrite rulesets could delete the approval requirement, which is strictly stronger than approving its own work. CI only ever *reads* rulesets, with a read-only credential.
+- **Rollback is one phone-executable command**, stated in Task 6 Step 8 and repeated in the kill-switch pattern guide:
+  `gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled`
+- **`ci.yml` is never gated on `FACTORY_ENABLED`.** It produces the required check; gating it would make every PR permanently unmergeable the moment the kill switch is flipped. The kill switch gates *agent* jobs only.
+- **Two credential buckets stay separate** (ADR-0012): the factory runs on the flat `CLAUDE_CODE_OAUTH_TOKEN` seat; `ANTHROPIC_API_KEY` stays scoped to `live-eval.yml`. Nothing here touches `live-eval.yml`'s triggers or credentials.
+- **ADRs are amended, never edited** (`docs/knowledge/README.md` persist protocol). ADR-0012 and ADR-0017 get blockquote amendments in the style ADR-0015 already uses; their bodies are left intact.
+- **`docs/superpowers/specs/` and `docs/superpowers/plans/` are immutable history** and are excluded from the doc sweep in Task 8.
+- Commit messages end with the repo's trailers:
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap`
+- All work lands on branch `agent/f0-harden-the-gate`, opened as a PR against `master`. Implements GitHub issue **#73** and closes **#71**.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `.github/workflows/ci.yml` | **Modify.** Fork-PR fix on both reporting steps (Task 1); `concurrency` with `cancel-in-progress: false` (Task 3). Never kill-switched. |
+| `.github/workflows/claude-code-review.yml` | **Modify.** `concurrency` `cancel-in-progress: true`, `timeout-minutes`, `FACTORY_ENABLED` gate, failure alert. |
+| `.github/workflows/claude.yml` | **Modify.** `timeout-minutes`, `FACTORY_ENABLED` gate, failure alert. |
+| `.github/workflows/housekeeping.yml` | **Modify.** `timeout-minutes`, `FACTORY_ENABLED` gate, `issues: write`, failure alert; `::add-mask::` for the derived auth header and the comment-fragment tidy (#71). |
+| `.github/workflows/ruleset-drift.yml` | **New.** Daily read-only drift check: live rulesets vs committed JSON. Fails loudly; not kill-switched. |
+| `.github/rulesets/R1-all-branches.json` | **New.** Desired state for ruleset `8769144` — `~ALL`, `deletion` + `non_fast_forward`. |
+| `.github/rulesets/R2-default-branch.json` | **New.** Desired state for the new ruleset — `~DEFAULT_BRANCH`, `pull_request{1}` + `required_status_checks[Build & verify]`. |
+| `scripts/rulesets/apply-rulesets.sh` | **New.** Local-only applier. Refuses to run under `GITHUB_ACTIONS`. |
+| `scripts/rulesets/check-drift.sh` | **New.** Read-only comparator, shared by the workflow and by local runs. |
+| `docs/knowledge/patterns/factory-kill-switch.md` | **New.** The escalation ladder + rollback commands, written to be readable and executable from a phone. |
+| `docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md` | **New (persist).** Two rulesets, identical bypass, local-only apply, drift check. |
+| `docs/knowledge/decisions/ADR-0012-live-eval-harness.md` | **Amend (not edit).** Blockquote amendment: the harness is dispatch-only, not post-merge. |
+| `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md` | **Amend (not edit).** Same correction to its "Relationship to ADR-0012" wording. |
+| `docs/knowledge/README.md` | **Modify (persist).** Link ADR-0019 and the new pattern guide. |
+| `docs/knowledge/roadmap.md` | **Modify (persist).** Close the F0 row; fix six stale "post-merge" claims. |
+| `docs/knowledge/gotchas.md` | **Modify (persist).** Three new entries; fix two stale "post-merge" claims. |
+| `CLAUDE.md`, `README.md`, `CONTRIBUTING.md` | **Modify.** Stale "post-merge" live-eval claim. |
+
+---
+
+### Task 1: Unblock fork PRs in `ci.yml` before any required check exists
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `Publish test results` step, lines 44–51; the `Publish coverage summary` step, lines 56–64)
+
+**Interfaces:**
+- Consumes: `secrets.GITHUB_TOKEN` (read-only on fork `pull_request` events — this is the constraint being worked around).
+- Produces: a `Build & verify` job that reaches a `success` conclusion on a PR from a forked repository, making it safe to pin as a required status check in Task 6.
+
+For a `pull_request` event from a **forked** repository, `GITHUB_TOKEN` is read-only *regardless of the workflow's `permissions:` key* — the key can only reduce a token's scopes, never raise them above what the event grants. `mikepenz/action-junit-report` writes a check run (checks API) and `madrapps/jacoco-report` posts a PR comment; both receive `403` and, with no `continue-on-error`, fail the job. So `Build & verify` fails on **every outside contribution today**. Pinning it as a required check before fixing this would render outside contributions to a **public portfolio repo** permanently unmergeable. This is why it is Task 1 and not a footnote.
+
+Two mitigations are applied together: the coverage step is *skipped* on forks (it can produce nothing there, so running it is pure noise), and both steps are made non-fatal so any residual permission surprise degrades to a missing report rather than a red required check.
+
+- [ ] **Step 1: Make the JUnit reporter non-fatal**
+
+In `.github/workflows/ci.yml`, change:
+```yaml
+      # Publish JUnit results as a check run with inline annotations, even when
+      # the build failed, so failing tests are visible on the PR.
+      - name: Publish test results
+        if: always()
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: 'JUnit Test Results'
+          annotate_only: true
+          require_tests: true
+```
+to:
+```yaml
+      # Publish JUnit results as a check run with inline annotations, even when
+      # the build failed, so failing tests are visible on the PR.
+      #
+      # continue-on-error: for a `pull_request` from a FORK, GITHUB_TOKEN is read-only
+      # regardless of this workflow's `permissions:` block (the key can only reduce), so the
+      # checks-API write 403s. Reporting is signal, never the gate — `Build & verify` is a
+      # required status check (see .github/rulesets/R2-default-branch.json) and must not go
+      # red because a reporter could not write. The `./gradlew build` step above is the gate.
+      - name: Publish test results
+        if: always()
+        continue-on-error: true
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: 'JUnit Test Results'
+          annotate_only: true
+          require_tests: true
+```
+
+- [ ] **Step 2: Skip the coverage comment on forks and make it non-fatal**
+
+In the same file, change:
+```yaml
+      - name: Publish coverage summary
+        if: github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.1
+```
+to:
+```yaml
+      # Skipped on fork PRs: the read-only fork GITHUB_TOKEN cannot post a PR comment, so this
+      # can only 403. continue-on-error covers the residual case (e.g. a comment-locked PR).
+      - name: Publish coverage summary
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
+        uses: madrapps/jacoco-report@v1.7.1
+```
+
+- [ ] **Step 3: Lint the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 4: Confirm the gate itself is untouched**
+
+Run: `grep -n "continue-on-error" .github/workflows/ci.yml`
+Expected: exactly two lines, both inside the reporting steps — and **no** `continue-on-error` on `Build with Gradle Wrapper`. If the build step ever gains one, the required check becomes decorative.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+fix(ci): stop fork PRs failing Build & verify on reporter 403s
+
+For a pull_request from a fork, GITHUB_TOKEN is read-only regardless of the
+workflow's permissions: block, so mikepenz/action-junit-report (checks API) and
+madrapps/jacoco-report (PR comment) both 403 and fail the job. Skip the coverage
+comment on forks and mark both reporters continue-on-error so the job's
+conclusion reflects ./gradlew build only.
+
+Prerequisite for pinning "Build & verify" as a required status check (#73):
+without it, every outside contribution to a public repo would be unmergeable.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 2: Confirm the check-run name from a real run
+
+**Files:** none (evidence-gathering task; its output is consumed verbatim by Task 6)
+
+**Interfaces:**
+- Consumes: the GitHub checks API for a commit that has a completed `ci.yml` run.
+- Produces: the exact string to place in `required_status_checks[].context`. A required check whose context does not match a real check-run name never turns green and blocks the PR forever with no visible cause.
+
+The name is **not** the workflow name (`CI`) and **not** the job key (`build`) — it is the job's `name:` (`.github/workflows/ci.yml` line 16, `name: Build & verify`). Confirm it against the API rather than reading it off the YAML, because that is the string the ruleset matches.
+
+- [ ] **Step 1: List check-run names on the current `master` head**
+
+Run:
+```bash
+SHA="$(gh api repos/Muddl/riot-api-mcp-server/commits/master --jq '.sha')"
+echo "sha=$SHA"
+gh api "repos/Muddl/riot-api-mcp-server/commits/$SHA/check-runs" \
+  --jq '.check_runs[] | "\(.name) | \(.conclusion) | app_id=\(.app.id)"'
+```
+Expected: two lines, one of which is exactly `Build & verify`. Observed on `18cebda3e6563d50355f1c52f1e6726fb3015add`:
+```
+Build & verify | null | app_id=15368
+Submit dependency graph | success | app_id=15368
+```
+(`conclusion: null` simply means that run was still in flight when sampled; the **name** is what matters.) If the string differs by so much as the ampersand spacing, use the API's value in Task 6, not this plan's.
+
+- [ ] **Step 2: Record the ampersand hazard**
+
+Run: `gh api repos/Muddl/riot-api-mcp-server/commits/master/check-runs --jq '.check_runs[].name' | cat -A | grep -n 'Build'`
+Expected: `Build & verify$` — a literal space-ampersand-space, no HTML entity, no trailing whitespace. Anything else means the JSON in Task 6 must be adjusted to match byte-for-byte.
+
+- [ ] **Step 3: Decide on `integration_id`**
+
+`required_status_checks[].integration_id` optionally pins the *app* allowed to report that context, which prevents a third party from satisfying the check with a same-named run. Step 1 printed `app_id=15368` (GitHub Actions). **This plan omits `integration_id`** from the committed JSON: it is one more value that can drift silently, and this repo grants no third party check-write access. If you choose to pin it, add `"integration_id": <value from Step 1>` to the object in Task 6 Step 2 and to nothing else — the drift check will then hold it.
+
+No commit: this task produces evidence, not files. Carry the confirmed string `Build & verify` into Task 6.
+
+---
+
+### Task 3: Bound the agent jobs — concurrency and timeouts
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (insert a `concurrency:` block after the `on:` block, before the `permissions:` block at line 11)
+- Modify: `.github/workflows/claude-code-review.yml` (insert `concurrency:` after the `on:` block, line 5; add `timeout-minutes` to the `claude-review` job)
+- Modify: `.github/workflows/claude.yml` (add `timeout-minutes` to the `claude` job)
+- Modify: `.github/workflows/housekeeping.yml` (add `timeout-minutes` to the `housekeeping` job)
+
+**Interfaces:**
+- Produces: no `ci.yml` run is ever *cancelled* by a newer one; every job that runs `claude-code-action` terminates on its own within a stated wall-clock bound.
+
+Two facts drive opposite settings. **A cancelled check run never satisfies a required status check** — it reports `conclusion: cancelled`, which is neither success nor a pending state GitHub will wait on, so a superseded `ci.yml` run would leave the PR blocked with a stale grey check and no obvious cause. Hence `cancel-in-progress: false` on `ci.yml`. On `claude-code-review.yml` a superseded review is pure waste, so `true`. Separately, `claude-code-action` **exposes no timeout of its own** — its message loop runs until the job's `timeout-minutes` (default 360, i.e. six hours of a flat-rate seat).
+
+- [ ] **Step 1: Serialise `ci.yml` per ref, never cancelling**
+
+In `.github/workflows/ci.yml`, change:
+```yaml
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+# Least-privilege default for the whole workflow. Individual jobs elevate only
+```
+to:
+```yaml
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+# Queue, never cancel. `Build & verify` is a REQUIRED status check on master
+# (.github/rulesets/R2-default-branch.json), and a *cancelled* check run does not satisfy a
+# required check — it is neither success nor a pending state the merge box waits on. Cancelling
+# a superseded run would leave the PR blocked behind a grey check with no visible cause.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+# Least-privilege default for the whole workflow. Individual jobs elevate only
+```
+
+- [ ] **Step 2: Cancel superseded reviews, and bound the review job**
+
+In `.github/workflows/claude-code-review.yml`, change:
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+```
+to:
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+# Opposite of ci.yml on purpose: a review of an older commit is waste, not signal, and this
+# workflow produces no required check, so cancelling it blocks nothing.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # Without this the default is 360 minutes of flat-rate seat on a wedged review.
+    timeout-minutes: 20
+    permissions:
+```
+
+- [ ] **Step 3: Bound the `@claude` job**
+
+In `.github/workflows/claude.yml`, change:
+```yaml
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # post review comments when @claude-mentioned on a PR
+```
+to:
+```yaml
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write   # post review comments when @claude-mentioned on a PR
+```
+
+- [ ] **Step 4: Bound the housekeeping job**
+
+In `.github/workflows/housekeeping.yml`, change:
+```yaml
+jobs:
+  housekeeping:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create the housekeeping branch
+```
+to:
+```yaml
+jobs:
+  housekeeping:
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # This job runs unattended on a Monday cron — an unbounded hang is the worst case.
+    timeout-minutes: 30
+    permissions:
+      contents: write        # create the housekeeping branch
+```
+
+- [ ] **Step 5: Lint all four workflows**
+
+Run:
+```bash
+for f in ci claude claude-code-review housekeeping; do
+  python -c "import yaml; yaml.safe_load(open('.github/workflows/$f.yml')); print('$f ok')"
+done
+```
+Expected:
+```
+ci ok
+claude ok
+claude-code-review ok
+housekeeping ok
+```
+
+- [ ] **Step 6: Assert every `claude-code-action` job is now bounded**
+
+Run:
+```bash
+grep -l "claude-code-action" .github/workflows/*.yml | while read -r f; do
+  printf '%s: ' "$f"; grep -c "timeout-minutes:" "$f"
+done
+```
+Expected: `claude-code-review.yml: 1`, `claude.yml: 1`, `housekeeping.yml: 1` — every file that uses the action has a timeout. A `0` on any line means a job can still hang for six hours.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/claude-code-review.yml .github/workflows/claude.yml .github/workflows/housekeeping.yml
+git commit -m "$(cat <<'EOF'
+ci: bound agent jobs with timeouts and set concurrency deliberately
+
+ci.yml: cancel-in-progress false — a cancelled check run never satisfies a
+required status check and would block the PR behind a grey check with no
+visible cause. claude-code-review.yml: cancel-in-progress true, since a review
+of a superseded commit is waste and produces no required check.
+
+timeout-minutes on every job running claude-code-action: the action exposes no
+timeout of its own and its message loop runs until the job's (default 360).
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 4: Add the `FACTORY_ENABLED` kill switch and document the ladder
+
+**Files:**
+- Modify: `.github/workflows/claude.yml` (the job-level `if:` expression, lines 15–19)
+- Modify: `.github/workflows/claude-code-review.yml` (the job-level `if:`, now line ~16 after Task 3)
+- Modify: `.github/workflows/housekeeping.yml` (add a job-level `if:` to the `housekeeping` job)
+- Create: `docs/knowledge/patterns/factory-kill-switch.md`
+
+**Interfaces:**
+- Consumes: repository variable `FACTORY_ENABLED` (`vars.FACTORY_ENABLED`), created in Step 1.
+- Produces: a single toggle, flippable from a mobile browser at
+  `https://github.com/Muddl/riot-api-mcp-server/settings/variables/actions`, that stops every agent job while leaving `ci.yml` — and therefore the merge gate — fully operational.
+
+`vars.*` is always a **string**; comparing to `'true'` means an unset variable, a typo, or a deleted variable all evaluate false. That is the correct fail-safe direction: **absent means off**. `ci.yml` is deliberately not gated (see Global Constraints) — the required check must keep reporting when the factory is off, or flipping the switch would make every PR unmergeable.
+
+- [ ] **Step 1: Create the variable, on**
+
+Run:
+```bash
+gh variable set FACTORY_ENABLED --repo Muddl/riot-api-mcp-server --body "true"
+gh variable list --repo Muddl/riot-api-mcp-server
+```
+Expected: `FACTORY_ENABLED` present with value `true`. Create it **before** merging the workflow edits — a merged gate against a non-existent variable silently disables every agent job.
+
+- [ ] **Step 2: Gate the `@claude` job**
+
+In `.github/workflows/claude.yml`, change:
+```yaml
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+```
+to:
+```yaml
+    # Kill switch. vars.* is always a string, so an unset, deleted, or mistyped variable
+    # evaluates false — absent means OFF, which is the fail-safe direction. Flip it at
+    # /settings/variables/actions from any browser, phone included.
+    # See docs/knowledge/patterns/factory-kill-switch.md for the full escalation ladder.
+    if: |
+      vars.FACTORY_ENABLED == 'true' && (
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
+```
+
+- [ ] **Step 3: Gate the review job**
+
+In `.github/workflows/claude-code-review.yml`, change:
+```yaml
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    if: ${{ !github.event.pull_request.draft }}
+```
+to:
+```yaml
+    # Skip drafts — they aren't ready for review and would waste subscription usage.
+    # vars.FACTORY_ENABLED is the kill switch; absent/mistyped means OFF (fail-safe).
+    # This job produces no required check, so a skipped run blocks no merge.
+    if: ${{ !github.event.pull_request.draft && vars.FACTORY_ENABLED == 'true' }}
+```
+
+- [ ] **Step 4: Gate the housekeeping job**
+
+In `.github/workflows/housekeeping.yml`, change:
+```yaml
+jobs:
+  housekeeping:
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # This job runs unattended on a Monday cron — an unbounded hang is the worst case.
+    timeout-minutes: 30
+```
+to:
+```yaml
+jobs:
+  housekeeping:
+    # Kill switch. This is the only unattended cron in the factory, so it is the job the switch
+    # exists for. Absent/mistyped variable means OFF. Gating the job (not the step) also skips
+    # the git/PR steps, so a disabled factory opens no branches.
+    if: vars.FACTORY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # This job runs unattended on a Monday cron — an unbounded hang is the worst case.
+    timeout-minutes: 30
+```
+
+- [ ] **Step 5: Write the ladder as a KB pattern guide**
+
+Create `docs/knowledge/patterns/factory-kill-switch.md` with exactly this content:
+
+```markdown
+# Stopping the factory (escalation ladder)
+
+Every rung is reachable from a **mobile browser** with no laptop, no local checkout, and no
+`gh` install. Rungs are ordered least-destructive first; each is strictly stronger than the one
+above it. Use the lowest rung that solves the problem.
+
+## Rung 1 — flip `FACTORY_ENABLED` (seconds, reversible, no side effects)
+
+`https://github.com/Muddl/riot-api-mcp-server/settings/variables/actions` → `FACTORY_ENABLED` →
+Update → set to anything other than `true` (use `false`).
+
+Every agent job is gated on `vars.FACTORY_ENABLED == 'true'`, so this stops
+`claude.yml`, `claude-code-review.yml`, and `housekeeping.yml` at the job level: they report
+`skipped`, spend nothing, and create no branches.
+
+**What keeps running on purpose:** `ci.yml` (it produces the required `Build & verify` check —
+gating it would make every PR unmergeable), `ruleset-drift.yml` (a safety net must survive the
+kill switch), and `live-eval.yml` (manual dispatch only, metered bucket).
+
+Runs already **in flight** are not affected — the gate is evaluated at job start. Cancel them
+from the Actions tab if that matters.
+
+## Rung 2 — disable the workflow from the Actions tab (survives a variable being re-set)
+
+`https://github.com/Muddl/riot-api-mcp-server/actions` → pick the workflow → `···` →
+**Disable workflow**.
+
+Stronger than rung 1 because it is not a value another automation could set back, and because it
+prevents the run from being *created* rather than skipping it after creation.
+
+## Rung 3 — revoke `CLAUDE_CODE_OAUTH_TOKEN` (fails every agent run closed)
+
+`https://github.com/Muddl/riot-api-mcp-server/settings/secrets/actions` → delete
+`CLAUDE_CODE_OAUTH_TOKEN`, then revoke it at the Claude Code account level.
+
+Every `claude-code-action` step then fails authentication. This is the rung to use when the
+concern is "the agent is doing something harmful", not "the agent is wasting money": it is the
+only rung that cannot be undone by anything that already has repo write.
+
+Does **not** touch `ANTHROPIC_API_KEY`, which belongs to `live-eval.yml` alone (ADR-0012).
+
+## Ruleset rollback (separate axis — protection, not agents)
+
+If a ruleset change locks the repository — e.g. a required check that never reports, so nothing
+can merge — disable the ruleset rather than editing it. Copy-pasteable, and it works from the
+`gh` CLI on a phone or from any shell:
+
+```bash
+# R1 (~ALL: deletion, non_fast_forward) — id is stable and known
+gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled
+
+# R2 (~DEFAULT_BRANCH: PR approval + Build & verify) — id resolved by name
+gh api --method PUT \
+  "repos/Muddl/riot-api-mcp-server/rulesets/$(gh api repos/Muddl/riot-api-mcp-server/rulesets \
+    --jq '.[] | select(.name | startswith("R2")) | .id')" \
+  -f enforcement=disabled
+```
+
+Browser equivalent: `https://github.com/Muddl/riot-api-mcp-server/settings/rules` → the ruleset →
+Enforcement status → **Disabled** → Save.
+
+`enforcement: "evaluate"` (dry-run) is **GitHub Enterprise only** and is not available on this
+repository — there is no "try it safely" middle setting. Disabled or active.
+
+Re-enable by re-running `scripts/rulesets/apply-rulesets.sh` from a desk, which restores the
+committed JSON exactly and is then confirmed by `ruleset-drift.yml`.
+
+## After using any rung
+
+Say so on the alert thread (`vars.FACTORY_ALERT_ISSUE`) — an unexplained silent factory is
+indistinguishable from a broken one, which is the failure mode this whole sub-project exists to
+remove.
+```
+
+- [ ] **Step 6: Lint the YAML and confirm every agent job is gated**
+
+Run:
+```bash
+for f in claude claude-code-review housekeeping; do
+  python -c "import yaml; yaml.safe_load(open('.github/workflows/$f.yml')); print('$f ok')"
+done
+grep -c "FACTORY_ENABLED" .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/housekeeping.yml
+grep -c "FACTORY_ENABLED" .github/workflows/ci.yml
+```
+Expected: three `ok` lines; each of the three agent workflows reports `1` or more; **`ci.yml` reports `0`** (`grep -c` exits 1 with no match — that zero is the intended result, not an error).
+
+- [ ] **Step 7: Link the pattern guide from the KB README**
+
+In `docs/knowledge/README.md`, in the `### Patterns` list, immediately after:
+```markdown
+- [Run and extend the live eval harness](patterns/live-eval-harness.md)
+```
+add:
+```markdown
+- [Stopping the factory (escalation ladder)](patterns/factory-kill-switch.md)
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/housekeeping.yml docs/knowledge/patterns/factory-kill-switch.md docs/knowledge/README.md
+git commit -m "$(cat <<'EOF'
+feat(ci): add the FACTORY_ENABLED kill switch and document the ladder
+
+Every agent job now gates on vars.FACTORY_ENABLED == 'true'. vars.* is a
+string, so unset/deleted/mistyped evaluates false — absent means OFF. ci.yml is
+deliberately NOT gated: it produces the required Build & verify check, and
+gating it would make every PR unmergeable the moment the switch is flipped.
+
+Ladder (all phone-reachable): flip the variable -> disable the workflow from
+the Actions tab -> revoke CLAUDE_CODE_OAUTH_TOKEN. Recorded as a KB pattern
+guide with the copy-pasteable ruleset rollback commands alongside.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 5: Add a failure alert path that reaches a phone
+
+**Files:**
+- Modify: `.github/workflows/claude-code-review.yml` (append a final step to the `claude-review` job)
+- Modify: `.github/workflows/claude.yml` (append a final step to the `claude` job)
+- Modify: `.github/workflows/housekeeping.yml` (append a final step to the `housekeeping` job; add `issues: write` to its `permissions:` block)
+
+**Interfaces:**
+- Consumes: repository variable `FACTORY_ALERT_ISSUE` (a long-lived tracking issue number), created in Step 1; `secrets.GITHUB_TOKEN`.
+- Produces: an `@Muddl` mention comment on every agent-job failure. GitHub Mobile pushes mention notifications; `schedule`-failure email covers only scheduled workflows and never `issues`-triggered runs, so a mention is the only channel that covers both.
+
+`if: failure()` fires when any earlier step in the same job failed — including a `timeout-minutes` kill. It does **not** fire on `cancelled()`, which is correct: a cancellation is a human act, not a fault.
+
+- [ ] **Step 1: Create the alert tracking issue and record its number**
+
+Run:
+```bash
+gh issue create --repo Muddl/riot-api-mcp-server \
+  --title "Factory alerts (do not close)" \
+  --body "Long-lived thread. Agent workflows post an @Muddl mention here on failure so GitHub Mobile pushes a notification. Referenced by vars.FACTORY_ALERT_ISSUE. See docs/knowledge/patterns/factory-kill-switch.md."
+gh variable set FACTORY_ALERT_ISSUE --repo Muddl/riot-api-mcp-server --body "<number printed above>"
+gh variable list --repo Muddl/riot-api-mcp-server
+```
+Expected: an issue URL is printed, and `gh variable list` shows both `FACTORY_ENABLED` and `FACTORY_ALERT_ISSUE`. Substitute the real issue number for `<number printed above>` — do not leave a placeholder.
+
+- [ ] **Step 2: Alert from the review job**
+
+In `.github/workflows/claude-code-review.yml`, append to the end of the `claude-review` job's `steps:` list (after the `Run Claude Code Review` step), at the same indentation as `- name: Run Claude Code Review`:
+```yaml
+      # An unattended failure nobody sees is the same as no gate at all. `gh pr comment` uses
+      # this job's `pull-requests: write`; the @-mention is what makes GitHub Mobile push a
+      # notification (schedule-failure email does not cover pull_request-triggered runs).
+      # failure() deliberately excludes cancelled() — a cancellation is a human act.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --body \
+            "@Muddl \`Claude Code Review\` failed on this PR. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+```
+
+- [ ] **Step 3: Alert from the `@claude` job**
+
+In `.github/workflows/claude.yml`, append to the end of the `claude` job's `steps:` list (after the `Run Claude Code` step), at the same indentation as `- name: Run Claude Code`:
+```yaml
+      # Comments back on whichever issue or PR triggered the run. `gh issue comment` works on a
+      # PR number too (PRs are issues); this job already holds issues: write and
+      # pull-requests: write. The @-mention is the phone-notification channel.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh issue comment "$TARGET" --body \
+            "@Muddl \`Claude Code\` failed here. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+```
+
+- [ ] **Step 4: Grant `issues: write` to the housekeeping job**
+
+In `.github/workflows/housekeeping.yml`, change:
+```yaml
+    permissions:
+      contents: write        # create the housekeeping branch
+      pull-requests: write   # open the PR
+      id-token: write
+```
+to:
+```yaml
+    permissions:
+      contents: write        # create the housekeeping branch
+      pull-requests: write   # open the PR
+      issues: write          # post the @Muddl failure alert (see the last step)
+      id-token: write
+```
+
+- [ ] **Step 5: Alert from the housekeeping job**
+
+In `.github/workflows/housekeeping.yml`, append to the end of the `housekeeping` job's `steps:` list (after the `Open a PR if the pass changed anything` step), at the same indentation as `- name: Open a PR if the pass changed anything`:
+```yaml
+      # This is the only unattended cron in the factory: it fires at 09:00 UTC Monday with
+      # nobody watching. There is no issue or PR context here, so the alert goes to the
+      # long-lived tracking issue in vars.FACTORY_ALERT_ISSUE. If that variable is unset the
+      # step fails loudly rather than swallowing the alert — a silent alerter is worse than none.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERT_ISSUE: ${{ vars.FACTORY_ALERT_ISSUE }}
+        run: |
+          if [ -z "$ALERT_ISSUE" ]; then
+            echo "::error title=Alerting::FACTORY_ALERT_ISSUE is unset; the failure alert had nowhere to go."
+            exit 1
+          fi
+          gh issue comment "$ALERT_ISSUE" --body \
+            "@Muddl \`Weekly Housekeeping\` failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+```
+
+- [ ] **Step 6: Lint and confirm every agent workflow alerts**
+
+Run:
+```bash
+for f in claude claude-code-review housekeeping; do
+  python -c "import yaml; yaml.safe_load(open('.github/workflows/$f.yml')); print('$f ok')"
+done
+grep -c "if: failure()" .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/housekeeping.yml
+```
+Expected: three `ok` lines, then `1` for each of the three workflows.
+
+- [ ] **Step 7: Prove the mention actually notifies (do not skip — this is the whole point)**
+
+Run:
+```bash
+gh issue comment "$(gh variable list --repo Muddl/riot-api-mcp-server --json name,value \
+  --jq '.[] | select(.name=="FACTORY_ALERT_ISSUE") | .value')" \
+  --repo Muddl/riot-api-mcp-server \
+  --body "@Muddl alert-path smoke test — ignore. If this did not push to your phone, the alert path is decorative."
+```
+Expected: a GitHub Mobile push notification arrives on the phone within ~a minute. If it does not, check Settings → Notifications → *Participating, @mentions and custom* has **Mobile** ticked before treating any later `if: failure()` step as an alert.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/housekeeping.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): alert @Muddl on agent-job failure
+
+Every agent job gains an `if: failure()` step that posts a gh comment
+mentioning @Muddl — on the triggering PR/issue where there is one, and on the
+vars.FACTORY_ALERT_ISSUE thread for the unattended housekeeping cron.
+
+GitHub Mobile pushes mention notifications; schedule-failure email does not
+cover issues- or pull_request-triggered runs, so a mention is the only channel
+that covers the whole factory. failure() excludes cancelled() on purpose.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 6: Split the ruleset, apply it locally, and verify it on a schedule
+
+**Files:**
+- Create: `.github/rulesets/R1-all-branches.json`
+- Create: `.github/rulesets/R2-default-branch.json`
+- Create: `scripts/rulesets/apply-rulesets.sh`
+- Create: `scripts/rulesets/check-drift.sh`
+- Create: `.github/workflows/ruleset-drift.yml`
+
+**Interfaces:**
+- Consumes: the confirmed check-run name `Build & verify` from Task 2; the maintainer's own `gh` credential for writes; a read-only fine-grained PAT `RULESET_READ_TOKEN` for the scheduled check.
+- Produces: two active rulesets whose live configuration is asserted daily against committed JSON, and a red workflow the moment they diverge.
+
+**Disposition of ruleset `8769144`: updated in place with `PUT`, not replaced.** Its id is stable, already referenced in the roadmap, the spec, and the rollback command, and preserving it means the rollback in `factory-kill-switch.md` needs no lookup. The `pull_request` rule is *removed* from it and re-created inside R2; `deletion`, `non_fast_forward`, the `~ALL` include, the **`refs/heads/dependabot/*` exclude**, and the `{actor_id: 5, actor_type: RepositoryRole, bypass_mode: exempt}` bypass are all preserved verbatim.
+
+**Order matters: create R2 first, then narrow R1.** Doing it the other way opens a window in which `master` has no approval requirement at all. Both rulesets carry the **identical** admin-`exempt` bypass — GitHub documents that rules across rulesets are aggregated with "the most restrictive version of the rule applies" but documents **nothing** about how *bypass* is evaluated when several rulesets apply, and `enforcement: "evaluate"` (dry-run) is Enterprise-only. Identical bypass means that undocumented question never arises. The tighter variant (`bypass_actors: []` on R2, so nobody merges red) is deferred to a post-trip item gated on testing layered bypass on a **throwaway probe repo**, never on this one.
+
+**Residual risk, stated rather than solved:** the maintainer remains `exempt` and can still merge red. Machine identities — the ones that run unattended — cannot. That is the property F0 buys, and it is the whole property.
+
+- [ ] **Step 1: Commit R1's desired state**
+
+Create `.github/rulesets/R1-all-branches.json` with exactly this content:
+
+```json
+{
+  "name": "R1 — all branches: no deletion, no force-push",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "exempt"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+        "refs/heads/dependabot/*"
+      ],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}
+```
+
+`non_fast_forward` is kept on `~ALL` **on purpose**: F4 pushes revision rounds to live PR branches, where a force-push would erase round evidence and outdate every inline review comment. The dependabot exclude is carried over from the live ruleset unchanged.
+
+- [ ] **Step 2: Commit R2's desired state**
+
+Create `.github/rulesets/R2-default-branch.json` with exactly this content:
+
+```json
+{
+  "name": "R2 — default branch: PR approval + green build",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "exempt"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "Build & verify"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ]
+}
+```
+
+`"Build & verify"` is the string confirmed in Task 2 — byte-for-byte, ampersand and spacing included. `strict_required_status_checks_policy: false` means a PR need not be rebased onto the newest `master` before merging; `true` would force a re-run of `Build & verify` on every intervening master commit, which on a solo repo is friction without signal.
+
+- [ ] **Step 3: Write the local-only applier**
+
+Create `scripts/rulesets/apply-rulesets.sh` with exactly this content:
+
+```bash
+#!/usr/bin/env bash
+# Apply the committed ruleset JSON to GitHub. LOCAL ONLY — never from CI.
+#
+# Why local: a workflow able to rewrite rulesets could delete the approval requirement, which is
+# strictly stronger than approving its own work and violates the standing constraint that
+# automation may propose but never approve. Ruleset writes need `administration: write`; this
+# script uses the maintainer's own `gh` credential (an OAuth token with `repo` scope, or a
+# fine-grained PAT with Administration: read and write). No such credential exists in Actions,
+# and none is ever added.
+#
+# Usage:  scripts/rulesets/apply-rulesets.sh [--dry-run]
+set -euo pipefail
+
+REPO="${RULESET_REPO:-Muddl/riot-api-mcp-server}"
+R1_ID=8769144                       # existing ruleset, updated in place so its id stays stable
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.github/rulesets" && pwd)"
+DRY_RUN=false
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=true
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  echo "REFUSING: this script must never run in GitHub Actions. See ADR-0019." >&2
+  exit 1
+fi
+
+command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq not found" >&2; exit 1; }
+gh auth status >/dev/null || { echo "gh is not authenticated" >&2; exit 1; }
+
+ruleset_id_by_name() {
+  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$1\") | .id" | head -n1
+}
+
+apply() {  # apply <json-file> [known-id]
+  local file="$DIR/$1" id="${2:-}" name
+  name="$(jq -r .name "$file")"
+  [ -n "$id" ] || id="$(ruleset_id_by_name "$name")"
+  if $DRY_RUN; then
+    echo "would ${id:+PUT $id}${id:+ }${id:-POST} <- $1 ($name)"
+    return 0
+  fi
+  if [ -n "$id" ]; then
+    echo "PUT  $REPO/rulesets/$id  <- $1"
+    gh api --method PUT "repos/$REPO/rulesets/$id" --input "$file" >/dev/null
+  else
+    echo "POST $REPO/rulesets      <- $1"
+    gh api --method POST "repos/$REPO/rulesets" --input "$file" >/dev/null
+  fi
+}
+
+# ORDER IS LOAD-BEARING. R2 carries the approval requirement that R1 is about to lose; creating
+# R2 first means the default branch is never, even briefly, without one.
+apply R2-default-branch.json
+apply R1-all-branches.json "$R1_ID"
+
+echo
+echo "Applied. Verifying against the committed JSON:"
+exec "$(dirname "${BASH_SOURCE[0]}")/check-drift.sh"
+```
+
+- [ ] **Step 4: Write the read-only drift comparator**
+
+Create `scripts/rulesets/check-drift.sh` with exactly this content:
+
+```bash
+#!/usr/bin/env bash
+# Compare the live rulesets against the committed JSON. READ ONLY — makes no writes at all.
+# Runs both locally and from ruleset-drift.yml so there is exactly one implementation.
+#
+# `.github/rulesets/` is not a GitHub-recognised path; nothing on GitHub's side reads it. Without
+# this check the committed JSON is documentation cosplaying as configuration — ADR-0018's exact
+# failure shape, artifact present, property absent.
+set -euo pipefail
+
+REPO="${RULESET_REPO:-Muddl/riot-api-mcp-server}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.github/rulesets" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+status=0
+
+# Server-generated fields that are not part of the desired state.
+STRIP='del(.id, .node_id, ._links, .created_at, .updated_at, .source, .source_type, .current_user_can_bypass)'
+
+for file in R1-all-branches.json R2-default-branch.json; do
+  name="$(jq -r .name "$DIR/$file")"
+  id="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id" | head -n1)"
+  if [ -z "$id" ]; then
+    echo "::error title=Ruleset drift::No live ruleset named \"$name\". Expected from $file."
+    status=1
+    continue
+  fi
+  gh api "repos/$REPO/rulesets/$id" | jq -S "$STRIP" > "$TMP/live.json"
+  jq -S . "$DIR/$file" > "$TMP/want.json"
+  if diff -u "$TMP/want.json" "$TMP/live.json" > "$TMP/diff.txt"; then
+    echo "ok   $file (id $id) matches live"
+  else
+    echo "::error title=Ruleset drift::Live ruleset $id (\"$name\") differs from $file"
+    cat "$TMP/diff.txt"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "Live branch protection no longer matches the committed intent. Either someone hand-edited"
+  echo "a ruleset in the UI, or the committed JSON was changed without applying it. Reconcile with"
+  echo "scripts/rulesets/apply-rulesets.sh (locally, at a desk) or update the JSON to match."
+fi
+exit "$status"
+```
+
+- [ ] **Step 5: Write the scheduled drift workflow**
+
+Create `.github/workflows/ruleset-drift.yml` with exactly this content:
+
+```yaml
+name: Ruleset Drift
+
+on:
+  schedule:
+    - cron: '17 7 * * *'   # daily 07:17 UTC — offset off the hour to dodge cron congestion
+  workflow_dispatch:
+
+# READ ONLY, deliberately. GITHUB_TOKEN has no `administration` scope at all — the permissions
+# key does not offer one — so ruleset reads use a dedicated fine-grained PAT whose ONLY grant is
+# Administration: read. No credential in this repository's Actions can write a ruleset; that is
+# the point (see ADR-0019).
+permissions:
+  contents: read
+
+# NOT gated on vars.FACTORY_ENABLED. This is the safety net that tells you the gate is still
+# there; it must keep running precisely when the factory has been switched off.
+concurrency:
+  group: ruleset-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Ruleset drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write    # post the @Muddl alert on drift
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compare live rulesets against committed JSON
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_READ_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error title=Ruleset drift::RULESET_READ_TOKEN is not set. Refusing to skip green — an unverifiable gate is indistinguishable from an absent one. Create a fine-grained PAT scoped to this repo with Administration: read (and nothing else) and add it as the RULESET_READ_TOKEN secret."
+            exit 1
+          fi
+          bash scripts/rulesets/check-drift.sh
+
+      - name: Alert on drift
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERT_ISSUE: ${{ vars.FACTORY_ALERT_ISSUE }}
+        run: |
+          if [ -z "$ALERT_ISSUE" ]; then
+            echo "::error title=Alerting::FACTORY_ALERT_ISSUE is unset; the drift alert had nowhere to go."
+            exit 1
+          fi
+          gh issue comment "$ALERT_ISSUE" --body \
+            "@Muddl **Branch protection has drifted** from \`.github/rulesets/\`. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+```
+
+- [ ] **Step 6: Create the read-only credential**
+
+Create a **fine-grained** personal access token at
+`https://github.com/settings/personal-access-tokens/new`, scoped to **only** `Muddl/riot-api-mcp-server`, with repository permission **Administration: Read-only** and nothing else. Then:
+```bash
+gh secret set RULESET_READ_TOKEN --repo Muddl/riot-api-mcp-server
+gh secret list --repo Muddl/riot-api-mcp-server
+```
+Expected: `RULESET_READ_TOKEN` listed. Verify it is genuinely read-only before trusting it:
+```bash
+GH_TOKEN=<the new token> gh api repos/Muddl/riot-api-mcp-server/rulesets --jq '.[].name'
+GH_TOKEN=<the new token> gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f name="probe" 2>&1 | head -3
+```
+Expected: the first prints ruleset names; the second **fails with 403/404**. A token that can write is the wrong token — reissue it.
+
+- [ ] **Step 7: Apply the rulesets, then reconcile the JSON with GitHub's echo**
+
+Run:
+```bash
+bash scripts/rulesets/apply-rulesets.sh --dry-run
+bash scripts/rulesets/apply-rulesets.sh
+```
+Expected: the dry run prints one `would PUT 8769144` line and one `would POST`/`would PUT` line for R2; the real run applies both and then executes `check-drift.sh`.
+
+The drift check will very likely report a diff on the first run: GitHub echoes back default parameters this plan deliberately did not invent (for example `required_reviewers: []` on the `pull_request` rule, or additional `required_status_checks` defaults). **This is expected and is the reconciliation step, not a failure.** For each reported difference, copy the *live* side into the committed JSON — GitHub's echo is the authority on its own normalisation — and re-run:
+```bash
+bash scripts/rulesets/check-drift.sh
+```
+Expected, once reconciled:
+```
+ok   R1-all-branches.json (id 8769144) matches live
+ok   R2-default-branch.json (id <new id>) matches live
+```
+Do not relax `check-drift.sh` to a subset comparison to make this pass. An exact diff is what makes a hand-edit detectable.
+
+- [ ] **Step 8: Confirm the rollback command works, then restore**
+
+Run (this is the exact command in `factory-kill-switch.md`, so it must be proven, not assumed):
+```bash
+gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled
+gh api repos/Muddl/riot-api-mcp-server/rulesets/8769144 --jq .enforcement
+bash scripts/rulesets/check-drift.sh; echo "drift-exit=$?"
+gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=active
+gh api repos/Muddl/riot-api-mcp-server/rulesets/8769144 --jq .enforcement
+```
+Expected, in order: `disabled`; then the drift check reports a diff and `drift-exit=1` (proving the check notices a hand-edit — this is the Task 9 acceptance criterion rehearsed at a desk); then `active`; then a clean `check-drift.sh`.
+
+- [ ] **Step 9: Confirm the applier refuses to run in CI**
+
+Run: `GITHUB_ACTIONS=true bash scripts/rulesets/apply-rulesets.sh; echo "exit=$?"`
+Expected:
+```
+REFUSING: this script must never run in GitHub Actions. See ADR-0019.
+exit=1
+```
+
+- [ ] **Step 10: Lint the workflow and shell-check the scripts**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ruleset-drift.yml')); print('ok')"
+bash -n scripts/rulesets/apply-rulesets.sh && echo "apply syntax ok"
+bash -n scripts/rulesets/check-drift.sh && echo "drift syntax ok"
+jq -e . .github/rulesets/R1-all-branches.json >/dev/null && echo "R1 json ok"
+jq -e . .github/rulesets/R2-default-branch.json >/dev/null && echo "R2 json ok"
+```
+Expected: `ok`, `apply syntax ok`, `drift syntax ok`, `R1 json ok`, `R2 json ok`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add .github/rulesets/R1-all-branches.json .github/rulesets/R2-default-branch.json .github/workflows/ruleset-drift.yml
+git add --chmod=+x scripts/rulesets/apply-rulesets.sh scripts/rulesets/check-drift.sh
+git commit -m "$(cat <<'EOF'
+feat(ci): split ruleset 8769144 in two and verify it on a schedule
+
+R1 (~ALL, ruleset 8769144 updated in place via PUT so its id stays stable):
+deletion + non_fast_forward. non_fast_forward stays on every branch because F4
+pushes revision rounds to live PR branches, where a force-push erases round
+evidence and outdates inline comments.
+
+R2 (~DEFAULT_BRANCH, new): pull_request{1 approval} +
+required_status_checks["Build & verify"], the name confirmed from a real
+check-runs response. R2 is created before R1 is narrowed so master is never
+without an approval requirement.
+
+Both rulesets keep the IDENTICAL admin-exempt bypass. GitHub documents rule
+aggregation across rulesets but documents nothing about bypass evaluation when
+several apply, and enforcement:"evaluate" (dry-run) is Enterprise-only, so the
+tighter bypass_actors:[] variant is deferred to a throwaway probe repo.
+
+The apply script refuses to run under GITHUB_ACTIONS: a workflow able to
+rewrite rulesets could delete the approval requirement, which is strictly
+stronger than approving its own work. Writes use the maintainer's own
+credential locally; ruleset-drift.yml reads with a fine-grained PAT scoped to
+Administration: read and fails loudly rather than skipping green.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 7: Close #71 — mask the derived auth header and tidy the comment
+
+**Files:**
+- Modify: `.github/workflows/housekeeping.yml` (the credential block, lines 98–120 in the pre-F0 file)
+
+**Interfaces:**
+- Consumes: `secrets.HOUSEKEEPING_TOKEN` (unchanged; F1 replaces it with a GitHub App).
+- Produces: `AUTH_HEADER` registered as a masked value, and a credential comment that reads as two coherent paragraphs.
+
+GitHub's automatic log redaction matches the **literal registered secret**, not transforms of it, so the base64 of `x-access-token:$GH_TOKEN` is not masked. Nothing currently prints it, so this is defence in depth — but `ACTIONS_STEP_DEBUG` traces would show it in the clear, and this step's credential handling has already broken in two non-obvious ways.
+
+- [ ] **Step 1: Split the dangling comment fragment and mask the header**
+
+In `.github/workflows/housekeeping.yml`, change:
+```yaml
+          # Restore a clean origin, then pass the PAT as a one-shot header on the push itself. An
+          # embedded `https://x-access-token:$TOKEN@...` remote would work too, but persists the
+          # token in .git/config for the rest of the job; `actions/checkout` avoids exactly that by
+          # using an extraheader, and this step — which exists to route around a credential footgun
+          # — should hold the same bar. The URL must be credential-free or its dead inline token
+          # would still be preferred over the header.
+          # GITHUB_SERVER_URL rather than a literal github.com, and the extraheader config key is
+          # derived from the same value so host and key cannot drift apart.
+          git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+```
+to:
+```yaml
+          # Restore a clean origin, then pass the PAT as a one-shot header on the push itself. An
+          # embedded `https://x-access-token:$TOKEN@...` remote would work too, but persists the
+          # token in .git/config for the rest of the job; `actions/checkout` avoids exactly that by
+          # using an extraheader, and this step — which exists to route around a credential footgun
+          # — should hold the same bar. The URL must be credential-free or its dead inline token
+          # would still be preferred over the header.
+          #
+          # The host comes from GITHUB_SERVER_URL rather than a literal github.com, and the
+          # extraheader config key below is derived from that same value, so the host and the
+          # config key cannot drift apart.
+          git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+
+          # GitHub's automatic log redaction matches the LITERAL registered secret, not transforms
+          # of it, so the base64 of "x-access-token:$GH_TOKEN" is NOT masked by default. Register
+          # it explicitly: nothing here prints it today, but ACTIONS_STEP_DEBUG tracing would show
+          # it in the clear. Defence in depth on a step whose credential handling has already
+          # broken twice. (#71)
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$AUTH_HEADER"
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/housekeeping.yml')); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Confirm the mask precedes every use of the value**
+
+Run: `grep -n 'AUTH_HEADER\|add-mask' .github/workflows/housekeeping.yml`
+Expected: three lines in this order — the `AUTH_HEADER=` assignment, then `echo "::add-mask::$AUTH_HEADER"`, then the `git -c http...extraheader="$AUTH_HEADER" push` line. A mask registered *after* a use protects nothing.
+
+- [ ] **Step 4: Verify the masking behaviour without dispatching the workflow**
+
+The workflow cannot be validated by dispatching from a branch: `claude-code-action` skips itself when the workflow file differs from the default branch, and the run goes **vacuously green** (`gotchas.md`). Replay the shell locally instead:
+```bash
+GH_TOKEN="fake-token-value" bash -c '
+  AUTH_HEADER="AUTHORIZATION: basic $(printf "x-access-token:%s" "$GH_TOKEN" | base64 -w0)"
+  echo "::add-mask::$AUTH_HEADER"
+  echo "header-length=${#AUTH_HEADER}"'
+```
+Expected: an `::add-mask::` line followed by `header-length=<n>` with `n > 30`. This proves the command is syntactically valid and runs before any use; the actual redaction is an Actions-runner behaviour and is confirmed in Task 9 by reading a real run's log.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/housekeeping.yml
+git commit -m "$(cat <<'EOF'
+chore(ci): mask the derived AUTH_HEADER and split the credential comment
+
+GitHub's log redaction matches the literal registered secret, not transforms of
+it, so the base64 of x-access-token:$GH_TOKEN was unmasked. Register it with
+::add-mask:: before first use. Nothing printed it, but ACTIONS_STEP_DEBUG would
+have shown it in the clear.
+
+Also breaks the GITHUB_SERVER_URL explanation out of the credential-handover
+block, where it read as a dangling fragment.
+
+Closes #71
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 8: Sweep the stale "post-merge" live-eval claim and persist F0
+
+**Files:**
+- Modify: `CLAUDE.md` (line ~41)
+- Modify: `README.md` (lines ~58 and ~61)
+- Modify: `CONTRIBUTING.md` (line ~48)
+- Modify: `docs/knowledge/roadmap.md` (lines ~115, ~188, ~211, ~316, ~317, ~328, ~332)
+- Modify: `docs/knowledge/gotchas.md` (lines ~157 and ~192; three new entries appended at the bottom)
+- Modify (**amend, never edit**): `docs/knowledge/decisions/ADR-0012-live-eval-harness.md`
+- Modify (**amend, never edit**): `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md`
+- Create: `docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md`
+- Modify: `docs/knowledge/README.md` (ADR list — add ADR-0019)
+
+**Interfaces:**
+- Consumes: the real trigger block of `.github/workflows/live-eval.yml`, which is `workflow_dispatch:` only.
+- Produces: no remaining prose outside immutable history that claims the live eval runs post-merge, plus the KB record of F0's decisions.
+
+`live-eval.yml`'s `push` trigger was removed and never replaced. `gotchas.md` records three bug classes only the live eval has ever caught — boxed-vs-primitive DTO fields, `snake_case` keys, live-vs-documented field names — every one of which passed the offline WireMock suite. So the stale claim is not cosmetic: it advertises a safety net that is not deployed.
+
+- [ ] **Step 1: Find every site**
+
+Run:
+```bash
+grep -rn "post-merge\|post merge" --include='*.md' . \
+  | grep -v '^\./docs/superpowers/' \
+  | grep -v '/build/'
+```
+Expected: matches in `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/knowledge/roadmap.md` (several), `docs/knowledge/gotchas.md`, and the two ADRs, plus `docs/knowledge/decisions/ADR-0018-housekeeping-pr-review-gate.md`. `docs/superpowers/` is excluded because dated specs and plans are immutable history. Work from this list, not from this plan's line numbers — they will have shifted.
+
+**ADR-0018's match is correct and must be left alone:** its "post-merge dispatch can verify the pass still runs" is about dispatching `housekeeping.yml` after a merge, not about the live eval.
+
+- [ ] **Step 2: Fix `CLAUDE.md`**
+
+Change:
+```
+The above is the offline CI gate and needs no keys. A separate **live eval harness** (`eval/`,
+Python + mcp-eval) runs agent-driven tests against the real Riot API post-merge over both transports
+```
+to:
+```
+The above is the offline CI gate and needs no keys. A separate **live eval harness** (`eval/`,
+Python + mcp-eval) runs agent-driven tests against the real Riot API over both transports,
+**dispatched manually** (`live-eval.yml` is `workflow_dispatch:` only — it does **not** run on merge)
+```
+
+- [ ] **Step 3: Fix `README.md`**
+
+Change:
+```
+Beyond the offline CI gate, a post-merge [live eval harness](eval/README.md) drives the server
+against the real Riot API over stdio and sse using [mcp-eval](https://mcp-eval.ai/), verifying the
+transports handshake, endpoint paths resolve, and Riot's error behaviours have not drifted. It runs
+post-merge only and never blocks a merge.
+```
+to:
+```
+Beyond the offline CI gate, a [live eval harness](eval/README.md) drives the server against the
+real Riot API over stdio and sse using [mcp-eval](https://mcp-eval.ai/), verifying the transports
+handshake, endpoint paths resolve, and Riot's error behaviours have not drifted. It is **dispatched
+on demand** (Actions tab or `gh workflow run live-eval.yml`) and never blocks a merge.
+```
+
+- [ ] **Step 4: Fix `CONTRIBUTING.md`**
+
+Change:
+```
+drives the server against the real Riot API with [mcp-eval](https://mcp-eval.ai/). It runs post-merge
+on CI and never blocks a merge. To run it locally you need `uv`, a personal `RIOT_API_KEY`, and an
+```
+to:
+```
+drives the server against the real Riot API with [mcp-eval](https://mcp-eval.ai/). It is dispatched
+on demand on CI (`workflow_dispatch`, not on merge) and never blocks a merge. To run it locally you
+need `uv`, a personal `RIOT_API_KEY`, and an
+```
+
+- [ ] **Step 5: Fix the five stale sites in `docs/knowledge/roadmap.md`**
+
+Apply each of these in place:
+
+1. Change `(continuously re-verified post-merge by the live eval harness once its` to `(continuously re-verified by dispatched runs of the live eval harness once its`.
+2. Change `plus the post-merge live eval harness ([ADR-0012](decisions/ADR-0012-live-eval-harness.md))` to `plus the dispatch-only live eval harness ([ADR-0012](decisions/ADR-0012-live-eval-harness.md))`.
+3. Change `Live agent-driven evals call every tool against the real Riot API post-merge; a wrong path returns 404 and fails the eval, so paths are verified continuously rather than by a human opening the portal.` to `Live agent-driven evals call every tool against the real Riot API on each dispatched run; a wrong path returns 404 and fails the eval, so paths are verified by running the harness rather than by a human opening the portal.`
+4. Change `The suite runs over both stdio and sse each post-merge run; a successful stdio session is the stdout-purity check.` to `The suite runs over both stdio and sse each dispatched run; a successful stdio session is the stdout-purity check.`
+5. Both standing-constraint italics read `this is automated post-merge by the live eval harness (`eval/`), over both transports; the offline suite remains the pre-merge gate.` — change **both** occurrences to `this is automated by the live eval harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite remains the pre-merge gate.`
+
+- [ ] **Step 6: Close the F0 roadmap row**
+
+In `docs/knowledge/roadmap.md`, replace the row:
+```markdown
+| **F0** | Harden the gate | ⏳ Not started | Ruleset surgery, the fork-PR fix that must precede any required check, bounds/kill-switch/alerting, #71, and the stale-doc sweep. Ships **no new agent behaviour**, so it is the only sub-project fully verifiable before it is depended on. |
+```
+with:
+```markdown
+| **F0** | Harden the gate | ✅ Shipped | [ADR-0019](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md). Ruleset `8769144` split into R1 (`~ALL`) + R2 (`~DEFAULT_BRANCH`, `Build & verify` required); fork PRs unblocked first; timeouts, `FACTORY_ENABLED` kill switch, `@Muddl` failure alerts, local-only apply script and a daily drift check. #71 closed and the stale-doc sweep done. |
+```
+
+- [ ] **Step 7: Fix the two stale sites in `docs/knowledge/gotchas.md`**
+
+1. Change `post-merge only (`.github/workflows/live-eval.yml`), and never blocks a merge.` to `on manual dispatch only (`.github/workflows/live-eval.yml` is `workflow_dispatch:`), and never blocks a merge.`
+2. Change `of failure offline instead of waiting for the post-merge live eval.` to `of failure offline instead of waiting for someone to dispatch the live eval.`
+
+- [ ] **Step 8: Append three new gotchas**
+
+Append to the **bottom** of `docs/knowledge/gotchas.md` (newest last, per the file's own convention):
+
+```markdown
+## `GITHUB_TOKEN` is read-only on fork PRs regardless of the `permissions:` block
+
+For a `pull_request` event from a **forked** repository, `GITHUB_TOKEN` is issued read-only. The
+workflow's `permissions:` key can only *reduce* a token's scopes, never raise them above what the
+event grants — so `checks: write` and `pull-requests: write` are silently ineffective there. Any
+step that writes (a check run, a PR comment, a label) gets `403` and, without `continue-on-error`,
+takes the whole job red. This made `Build & verify` fail on every outside contribution while nobody
+noticed, because no outside contribution had arrived.
+
+It matters far more once a job is a **required status check**: a reporter that cannot write then
+makes fork PRs permanently unmergeable. Keep reporting steps `continue-on-error: true` (or gate them
+on `github.event.pull_request.head.repo.fork == false`) so a job's conclusion reflects the build, not
+the reporter. The reverse is never acceptable — never put `continue-on-error` on the build step
+itself, which turns the required check into decoration.
+
+## A *cancelled* check run never satisfies a required status check
+
+`concurrency: cancel-in-progress: true` on a workflow that produces a required check is a trap. The
+superseded run reports `conclusion: cancelled`, which is neither a success nor a pending state the
+merge box waits on, so the PR sits blocked behind a grey check with no error anywhere to explain it.
+`ci.yml` therefore uses `cancel-in-progress: false` (queue, never cancel) while
+`claude-code-review.yml` — which produces no required check — uses `true`, where a superseded review
+is pure waste. Decide this per workflow by asking one question: *is this job's name pinned in a
+ruleset?*
+
+## `.github/rulesets/` is not a GitHub path, and `enforcement: "evaluate"` is Enterprise-only
+
+Committing ruleset JSON under `.github/rulesets/` configures nothing — GitHub reads no such path.
+Without something that applies it and something that verifies it, the JSON is documentation cosplaying
+as configuration, which is ADR-0018's exact failure shape: artifact present, property absent. This
+repo applies it with `scripts/rulesets/apply-rulesets.sh` (local only — a workflow able to rewrite
+rulesets could delete the approval requirement) and verifies it daily with `ruleset-drift.yml`, which
+fails loudly rather than skipping green when its read-only credential is missing.
+
+There is also no safe middle setting to rehearse a ruleset change in: `enforcement: "evaluate"`, the
+dry-run mode, is **"only available with GitHub Enterprise"** and does not exist on a free personal
+repo. Rulesets are `active` or `disabled`. Rehearse risky bypass topologies on a throwaway probe
+repo, never on this one — and note that GitHub documents rule *aggregation* across rulesets ("the most
+restrictive version of the rule applies") while documenting **nothing** about how *bypass* is
+evaluated when several rulesets match a ref. That silence is why R1 and R2 carry identical bypass.
+```
+
+- [ ] **Step 9: Amend ADR-0012 (do not edit its body)**
+
+In `docs/knowledge/decisions/ADR-0012-live-eval-harness.md`, change:
+```markdown
+# ADR-0012: Live agent-driven eval harness (mcp-eval)
+
+- **Status:** Accepted
+- **Date:** 2026-07-17
+
+## Context
+```
+to:
+```markdown
+# ADR-0012: Live agent-driven eval harness (mcp-eval)
+
+- **Status:** Accepted (amended 2026-08-01)
+- **Date:** 2026-07-17
+
+> **Amendment (2026-08-01):** the Decision's opening line — "run post-merge on CI" — and the
+> Consequences' "automated post-merge" were never true of the shipped workflow, and contradict this
+> ADR's own "On-demand, non-blocking" bullet below, which is the accurate one.
+> `.github/workflows/live-eval.yml` is `workflow_dispatch:` only; the `push` trigger was removed and
+> never replaced. **Merges get no live coverage unless someone dispatches the workflow by hand** —
+> which matters because `gotchas.md` records three bug classes only the live eval has ever caught,
+> every one of which passed the offline suite. Scheduling it was considered and rejected in the
+> [software-factory decomposition spec](../../superpowers/specs/2026-08-01-software-factory-decomposition-design.md):
+> the preflight *skips green* on a 401/403 and Riot dev keys expire every 24 hours, so a weekly cron
+> would yield one real run followed by green no-ops — reintroducing "silent failure that looks like
+> success" as the mitigation for it. The coverage gap during unattended weeks is recorded honestly
+> instead. Swept from all prose by F0 ([ADR-0019](ADR-0019-gate-hardening-and-ruleset-topology.md)).
+
+## Context
+```
+
+- [ ] **Step 10: Amend ADR-0017 (do not edit its body)**
+
+In `docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md`, change:
+```markdown
+# ADR-0017: Transport-scoped live eval coverage
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+
+## Context
+```
+to:
+```markdown
+# ADR-0017: Transport-scoped live eval coverage
+
+- **Status:** Accepted (amended 2026-08-01)
+- **Date:** 2026-07-23
+
+> **Amendment (2026-08-01):** "Relationship to ADR-0012" below describes the harness's purpose as
+> "agent-driven, live-Riot, post-merge, non-gating". Read **dispatch-only** for "post-merge":
+> `live-eval.yml` is `workflow_dispatch:` only and has never run on merge. Nothing else in this ADR
+> changes — the coverage narrowing it decides is independent of the trigger. See
+> [ADR-0012](ADR-0012-live-eval-harness.md)'s amendment and
+> [ADR-0019](ADR-0019-gate-hardening-and-ruleset-topology.md).
+
+## Context
+```
+
+- [ ] **Step 11: Write ADR-0019**
+
+Create `docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md` with exactly this content:
+
+```markdown
+# ADR-0019 — Gate hardening: ruleset topology, local-only application, and factory bounds
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+Repository ruleset `8769144` ("one ruleset to rule them all") had been active since 2025-10-09
+carrying `deletion`, `non_fast_forward`, and `pull_request{required_approving_review_count: 1}` —
+with **no required status checks at all** and with
+`{"actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "exempt"}`. `exempt` is stronger than
+`always`: rules are not evaluated for that actor and no bypass audit entry is written. So the one
+human was invisibly exempt from the only rule that existed, nothing required `Build & verify` to be
+green before merge, and the merge button was live on a red PR. Its `ref_name.include` was `~ALL`
+rather than the default branch, so a hypothetical agent branch was governed by the same
+PR-required rule as `master` — unreached only because the maintainer is exempt and `housekeeping.yml`
+performs a single branch *creation*.
+
+Separately, `ci.yml` could not pass on a fork PR at all: `GITHUB_TOKEN` is read-only for
+`pull_request` from a fork regardless of `permissions:`, and both reporting steps wrote through it
+with no `continue-on-error`. And no agent job had a timeout, a kill switch, or a failure alert.
+
+## Decision
+
+- **Fork PRs are fixed before any check becomes required.** Making `Build & verify` required while it
+  failed on every outside contribution would permanently block contributions to a public portfolio
+  repo. Reporting steps are non-fatal; the build step never is.
+- **Two rulesets, identical bypass.** R1 (`~ALL`) keeps `deletion` + `non_fast_forward` —
+  `non_fast_forward` stays repo-wide because F4 pushes revision rounds to live PR branches, where a
+  force-push erases round evidence and outdates every inline comment. R2 (`~DEFAULT_BRANCH`) carries
+  `pull_request{1 approval}` + `required_status_checks["Build & verify"]`. `8769144` is **updated in
+  place (PUT)** into R1 so its id — and therefore the rollback command — stays stable; R2 is created
+  first so `master` is never momentarily without an approval requirement.
+- **Bypass stays identical on both.** GitHub documents that rules across rulesets are aggregated with
+  "the most restrictive version of the rule applies" but documents **nothing** about how bypass is
+  evaluated when several rulesets match a ref, and `enforcement: "evaluate"` (dry-run) is
+  GitHub-Enterprise-only. An undocumented behaviour, no dry-run, and a sole maintainer who cannot
+  approve his own PRs is the combination not to experiment on. The tighter `bypass_actors: []`
+  variant is deferred, gated on testing layered bypass on a **throwaway probe repo**.
+- **Rulesets are applied locally and verified by CI, never applied by CI.** A workflow able to
+  rewrite rulesets could delete the approval requirement, which is strictly stronger than approving
+  its own work. Writes use the maintainer's own credential (`administration: write`) from
+  `scripts/rulesets/apply-rulesets.sh`, which refuses to run under `GITHUB_ACTIONS`. `ruleset-drift.yml`
+  reads with a fine-grained PAT scoped to **Administration: read** and nothing else, and fails loudly
+  when that secret is absent rather than skipping green.
+- **Bounds and control.** `timeout-minutes` on every job running `claude-code-action` (the action
+  exposes no timeout of its own). `cancel-in-progress: false` on `ci.yml` — a cancelled check run
+  never satisfies a required check — and `true` on `claude-code-review.yml`. Every agent job gates on
+  `vars.FACTORY_ENABLED == 'true'`; `ci.yml` and `ruleset-drift.yml` deliberately do not. Failures
+  post an `@Muddl` mention, the only channel GitHub Mobile pushes for `issues`- and
+  `pull_request`-triggered runs.
+
+## Consequences
+
+- **Machine identities cannot merge red.** That is the property this buys, and it is bounded: the
+  maintainer remains `exempt` and can still merge red. This residual risk is **stated, not solved**;
+  closing it for the human is a post-trip item.
+- Branch protection now has a committed, diffable definition, and a hand-edit in the GitHub UI turns a
+  daily workflow red within 24 hours instead of going unnoticed indefinitely.
+- Three phone-reachable rungs exist for stopping the factory
+  ([pattern guide](../patterns/factory-kill-switch.md)), and a ruleset lock-out is undone by one
+  copy-pasteable `gh api --method PUT ... -f enforcement=disabled`.
+- Every workflow file touched here contains `claude-code-action` or is adjacent to it, so the PR that
+  ships this receives **no Claude review** — the action refuses to run when the workflow file differs
+  from the default-branch copy and records that as an annotation on a *successful* job.
+- The live-eval "post-merge" claim is corrected everywhere outside immutable history; ADR-0012 and
+  ADR-0017 are amended rather than edited, per the knowledge-base reversal rule.
+```
+
+- [ ] **Step 12: Link ADR-0019 from the KB README**
+
+In `docs/knowledge/README.md`, immediately after the `ADR-0018` list item, add:
+```markdown
+- [ADR-0019 — Gate hardening: ruleset topology, local-only application, and factory bounds](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md)
+```
+
+- [ ] **Step 13: Verify the sweep is complete and the KB is intact**
+
+Run:
+```bash
+grep -rn "post-merge\|post merge" --include='*.md' . \
+  | grep -v '^\./docs/superpowers/' \
+  | grep -v '/build/' \
+  | grep -v 'ADR-0018' \
+  | grep -v '^\./docs/knowledge/decisions/ADR-001[27].*Amendment'
+```
+Expected: **no output**, apart from the amendment blockquotes in ADR-0012/ADR-0017 which quote the wrong phrasing in order to correct it. Any other hit is a site that was missed.
+
+Run:
+```bash
+comm -23 <(ls docs/knowledge/decisions/ADR-*.md | xargs -n1 basename | sort) <(grep -oE 'decisions/ADR-[0-9]{4}[^)]*\.md' docs/knowledge/README.md | sed 's|decisions/||' | sort -u)
+```
+Expected: empty output — every ADR on disk, including ADR-0019, is linked from the KB README.
+
+Run: `grep -c "workflow_dispatch" .github/workflows/live-eval.yml && grep -c "push:" .github/workflows/live-eval.yml`
+Expected: `1` then `0` — confirming the corrected prose matches the actual trigger, i.e. the sweep asserted a fact rather than a belief.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add CLAUDE.md README.md CONTRIBUTING.md docs/knowledge/roadmap.md docs/knowledge/gotchas.md docs/knowledge/README.md docs/knowledge/decisions/ADR-0012-live-eval-harness.md docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md
+git commit -m "$(cat <<'EOF'
+docs(kb): ADR-0019 gate hardening; sweep the stale post-merge live-eval claim
+
+live-eval.yml is workflow_dispatch: only — the push trigger was removed and
+never replaced — yet CLAUDE.md, README.md, CONTRIBUTING.md, roadmap.md,
+gotchas.md and two accepted ADRs advertised post-merge coverage. That is a
+safety net readers believed was deployed while three bug classes only the live
+eval has ever caught went uncovered on merge.
+
+ADR-0012 and ADR-0017 are AMENDED with dated blockquotes, never edited, per the
+knowledge-base reversal rule. docs/superpowers/ is untouched (immutable
+history). ADR-0019 records F0's decisions; the F0 roadmap row is closed.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
+EOF
+)"
+```
+
+---
+
+### Task 9: Verify the gate in production
+
+**Files:** none (integration/verification task)
+
+**Interfaces:**
+- Consumes: every prior task, on branch `agent/f0-harden-the-gate`, with the rulesets already applied live in Task 6.
+- Produces: falsifiable evidence for each of issue #73's acceptance criteria. **None of these is satisfied by a green Actions run** — three green-but-did-nothing incidents are on record in this repo.
+
+- [ ] **Step 1: Confirm the offline gate still passes**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`. No Java changed, but a red build here would mean the required check cannot go green and the PR is unmergeable by design.
+
+- [ ] **Step 2: Push and open the PR, stating the no-review expectation in the body**
+
+```bash
+git push -u origin agent/f0-harden-the-gate
+gh pr create --base master --head agent/f0-harden-the-gate \
+  --title "F0: harden the gate (fork-PR fix, ruleset split, kill switch, alerting)" \
+  --body "$(cat <<'EOF'
+Implements #73 — sub-project F0 of the software factory. Closes #71.
+Spec: `docs/superpowers/specs/2026-08-01-software-factory-decomposition-design.md` §1.
+Plan: `docs/superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md`.
+Decision record: ADR-0019.
+
+**Expect no Claude review on this PR — this is correct, not a failure.**
+`claude-code-action` hard-requires the workflow file to be byte-identical to the copy on the
+default branch. This PR edits `claude-code-review.yml` and `claude.yml`, so the action **skips
+itself** with `Skipping action due to workflow validation`, recorded as an *annotation on a
+successful job*. Do not read the missing review as the reviewer silently failing; see the
+matching entry in `docs/knowledge/gotchas.md`. The reviewer resumes on the next PR, once these
+files are on `master`.
+
+**Live configuration already applied.** The rulesets were applied from a desk in Task 6 (locally,
+never from CI). `master` now requires 1 approval and a green `Build & verify`. The maintainer
+remains `exempt` — a stated, unsolved residual risk; machine identities cannot merge red, which is
+the property F0 buys.
+
+Rollback, executable from a phone:
+`gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled`
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm `Build & verify` reports on this PR under the exact required name**
+
+Run:
+```bash
+gh pr checks --watch
+gh api "repos/Muddl/riot-api-mcp-server/commits/$(git rev-parse HEAD)/check-runs" \
+  --jq '.check_runs[] | "\(.name) | \(.conclusion)"'
+```
+**Falsifiable criterion:** a line reading exactly `Build & verify | success`. If the name differs by a byte from `.github/rulesets/R2-default-branch.json`, the required check will never be satisfied and every PR is blocked — fix the JSON, re-apply, and re-run `check-drift.sh` before merging anything.
+
+- [ ] **Step 4: Confirm a red PR cannot be merged by a non-exempt identity**
+
+The maintainer is `exempt`, so *his* merge button proves nothing. Test the property that matters — that the rule is evaluated at all — by inspecting the merge state on a deliberately-red PR:
+```bash
+git checkout -b probe/red-build
+printf '\nclass Boom { void x() { syntax error } }\n' >> lol-mcp-server/src/test/java/PROBE.java
+git add -A && git commit -m "probe: deliberately break the build (do not merge)"
+git push -u origin probe/red-build
+gh pr create --base master --head probe/red-build --title "probe: red build (do not merge)" --body "Throwaway. Verifies the required status check blocks merge."
+gh pr checks --watch || true
+gh pr view --json mergeable,mergeStateStatus,statusCheckRollup \
+  -q '{mergeable, state: .mergeStateStatus, checks: [.statusCheckRollup[] | {name, conclusion}]}'
+```
+**Falsifiable criterion:** `mergeStateStatus` is `BLOCKED` (not `CLEAN`, not `UNSTABLE`) and `Build & verify` shows `FAILURE`. `UNSTABLE` means checks are failing but nothing is *requiring* them — i.e. R2 did not take effect, and Task 6 must be re-run.
+
+Then clean up: `gh pr close probe/red-build --delete-branch` and `git checkout agent/f0-harden-the-gate`.
+
+- [ ] **Step 5: Confirm the drift check fails on a hand-edited ruleset**
+
+From a browser (this deliberately exercises the UI path, which is how real drift happens):
+`https://github.com/Muddl/riot-api-mcp-server/settings/rules` → **R2 — default branch: PR approval +
+green build** → change *Required approvals* from 1 to 0 → Save. Then:
+```bash
+gh workflow run ruleset-drift.yml
+sleep 30 && gh run list --workflow=ruleset-drift.yml --limit 1
+gh run view --log-failed --workflow=ruleset-drift.yml | head -40
+```
+**Falsifiable criterion:** the run's conclusion is `failure`, the log contains
+`::error title=Ruleset drift::`, a unified diff showing `required_approving_review_count` 1 → 0, and
+an `@Muddl` comment lands on `vars.FACTORY_ALERT_ISSUE`. A *green* run here means the comparator is
+normalising away the very field that changed — do not accept it.
+
+Restore: `bash scripts/rulesets/apply-rulesets.sh`, then re-run the workflow and confirm it goes
+green. A drift check that stays red after reconciliation is as useless as one that never goes red.
+
+- [ ] **Step 6: Exercise the kill-switch ladder from the actual phone**
+
+Do this **on the phone**, not on the laptop — the criterion is that the ladder is reachable without a
+desk, and that is only proven by reaching it without one. Follow
+`docs/knowledge/patterns/factory-kill-switch.md`.
+
+1. **Rung 1.** Phone browser → `/settings/variables/actions` → set `FACTORY_ENABLED` to `false`.
+   Post a comment containing `@claude ping` on any open issue.
+   **Falsifiable criterion:** the `Claude Code` workflow run for that comment shows the `claude` job
+   as **`skipped`**, not `success`, and no Claude reply appears. (A `success` conclusion with no
+   reply is the failure this criterion exists to distinguish.)
+2. **Rung 2.** Phone browser → Actions tab → `Weekly Housekeeping` → `···` → **Disable workflow**.
+   **Falsifiable criterion:** the workflow is listed as disabled and `gh workflow list` (later, from
+   a desk) shows `disabled_manually`. Re-enable afterwards.
+3. **Rung 3 — do not execute; verify reachability only.** Phone browser →
+   `/settings/secrets/actions`.
+   **Falsifiable criterion:** `CLAUDE_CODE_OAUTH_TOKEN` is visible with a working Remove control on
+   the phone viewport. Actually revoking it would require a desk to restore, so reachability is the
+   criterion; the *effect* (every agent step fails auth) is not in doubt.
+4. **Ruleset rollback.** From the phone browser: `/settings/rules` → R1 → Enforcement → Disabled →
+   Save → then back to Active.
+   **Falsifiable criterion:** both transitions complete on the phone viewport, and a subsequent
+   `ruleset-drift.yml` dispatch is green.
+
+Finally, restore rung 1: set `FACTORY_ENABLED` back to `true` and confirm a fresh `@claude` mention
+produces a job that **runs** rather than skips. An un-restored kill switch is a silently dead factory.
+
+- [ ] **Step 7: Confirm the fork-PR fix**
+
+Preferred, if a fork is available: push a trivial docs-only branch to a fork of this repository and
+open a PR from it.
+**Falsifiable criterion:** `Build & verify` reaches `success`; the run log shows the `Publish
+coverage summary` step as **skipped** (the `fork == false` guard) and, if `Publish test results`
+errored, the step is annotated with a warning while the **job** conclusion stays `success` (the
+`continue-on-error` path). A red `Build & verify` here means an outside contributor cannot merge and
+the required check must be removed until it is fixed.
+
+If no fork is available, this cannot be tested on this repository at all — a `pull_request` from the
+same repo issues a *writable* `GITHUB_TOKEN`, so the fork code path is never exercised, and no
+`workflow_dispatch` can simulate it. In that case record explicitly:
+
+- **What was reasoned, not tested:** the guard `github.event.pull_request.head.repo.fork == false`
+  evaluates false only on fork PRs, so the coverage step's behaviour on same-repo PRs is unchanged
+  (confirmed by Step 3, where the step ran); and `continue-on-error: true` is a runner-level
+  behaviour independent of which API returned the 403.
+- **What to watch for:** the first PR from any outside contributor. If `Build & verify` goes red on
+  it, disable R2's required-check rule immediately
+  (`gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/<R2-id> -f enforcement=disabled`)
+  rather than leaving a contributor blocked, and reopen #73.
+
+- [ ] **Step 8: Confirm the `::add-mask::` took effect in a real run**
+
+Run: `gh run view --log --workflow=housekeeping.yml --job "$(gh run list --workflow=housekeeping.yml --limit 1 --json databaseId --jq '.[0].databaseId')" 2>/dev/null | grep -c 'AUTHORIZATION: basic'`
+Expected: `0` — the header value never appears in a log. (This is only meaningful **after** the F0 PR
+merges, because `housekeeping.yml` runs the masked code only from `master`. Until then the mask is
+verified by the local replay in Task 7 Step 4.)
+
+- [ ] **Step 9: Merge, then confirm the gate held on the way through**
+
+Approve and merge the F0 PR. Then:
+```bash
+bash scripts/rulesets/check-drift.sh
+gh issue view 73 --json state -q .state
+gh issue view 71 --json state -q .state
+```
+Expected: a clean drift check, and both issues `CLOSED` (#71 by the commit trailer in Task 7, #73 by
+the PR body). If #73 did not auto-close, close it manually with a comment linking the four
+acceptance-criterion outcomes from Steps 4–7 — the criteria are the record, not the merge.
+
+---
+
+## Self-Review
+
+**Spec coverage** (spec §1, "F0 — Harden the gate"):
+- "Fork PRs must be fixed before any required check exists… **This is the first task in the plan, not a footnote**" → **Task 1**, with `continue-on-error` on both reporters plus a `fork == false` guard on the coverage comment. ✅
+- Confirm the check-run name before pinning it (issue #73 item 2) → **Task 2**, run against a real `check-runs` response; observed `Build & verify`. ✅
+- "Ruleset surgery, as two rulesets with identical bypass" — R1 `~ALL` `deletion`+`non_fast_forward`, R2 `~DEFAULT_BRANCH` `pull_request{1}`+`required_status_checks[Build & verify]` → **Task 6** Steps 1–2, with `8769144` updated in place via PUT (stated explicitly) and R2 created first. ✅
+- "Both keep the identical admin-`exempt` bypass"; `bypass_actors: []` deferred; `enforcement: "evaluate"` is Enterprise-only → **Task 6** preamble, ADR-0019, and `factory-kill-switch.md`. No JSON contains `evaluate`. ✅
+- "The residual risk is stated, not solved" → **Task 6** preamble, ADR-0019 Consequences, PR body (Task 9 Step 2). ✅
+- "Configuration must be applied, or it is not configuration" — local-only apply script, scheduled drift check → **Task 6** Steps 3–5, with a hard `GITHUB_ACTIONS` refusal proven in Step 9 and a loud-failure path when the read credential is absent. ✅
+- "Bounds and control" — `timeout-minutes` on every agent job; `cancel-in-progress: false` on `ci.yml`, `true` on `claude-code-review.yml` → **Task 3**, with a grep assertion that every `claude-code-action` file is bounded. ✅
+- "A kill switch and an alert path" — `vars.FACTORY_ENABLED == 'true'`, three-rung ladder, `if: failure()` → `gh issue comment` mentioning `@Muddl` → **Tasks 4 and 5**. ✅
+- "**The plan must require testing the ladder from the actual phone before departure**" → **Task 9 Step 6**, four sub-criteria, each falsifiable, explicitly phone-only. ✅
+- "Two corrections carried along" — #71's `::add-mask::` + comment tidy; the stale "post-merge" sweep with ADR-0012/0017 **amended, not edited** → **Tasks 7 and 8**, amendments in ADR-0015's blockquote style, `docs/superpowers/` excluded from the grep. ✅
+- "Editing `claude-code-review.yml` means that PR will not be reviewed by Claude… must be stated in the PR" → Global Constraints, ADR-0019 Consequences, and verbatim in the PR body in **Task 9 Step 2**. ✅
+- Rollback is a copy-pasteable `gh api --method PUT … -f enforcement=disabled`, phone-executable → Global Constraints, `factory-kill-switch.md`, PR body, and **proven** in **Task 6 Step 8**. ✅
+- "Ruleset writes need `administration: write` — say which credential and where" → writes: maintainer's own `gh` credential, locally, `apply-rulesets.sh`; reads: `RULESET_READ_TOKEN`, fine-grained, **Administration: read only**, verified non-writable in **Task 6 Step 6**. ✅
+- "A green Actions run is not proof of success" → Global Constraints; every Task 9 criterion asserts an effect (`mergeStateStatus: BLOCKED`, `skipped` not `success`, a red drift run with a diff), never an exit status. ✅
+
+**Placeholder scan:** No TBD/TODO/FIXME. Three values are resolved at execution time and each has an exact derivation command rather than a guess: the alert issue number (**Task 5 Step 1**, `gh issue create` then `gh variable set`), R2's ruleset id (resolved by *name* in both scripts, so it is never hardcoded — and the one place it appears in prose, the rollback for R2, uses a `--jq` lookup), and GitHub's echoed ruleset defaults (**Task 6 Step 7**, reconciled from the live response rather than invented here). `integration_id` is deliberately omitted with the reason and the derivation command stated in **Task 2 Step 3**. `8769144` is a real, verified id; `actor_id: 5` / `RepositoryRole` / the `refs/heads/dependabot/*` exclude are copied verbatim from the live ruleset.
+
+**Type/name consistency:** `Build & verify` appears identically in `ci.yml` (job `name:`), `R2-default-branch.json` (`context`), Task 2's confirmation, and Task 9's criteria — one string, byte-for-byte, ampersand included. `vars.FACTORY_ENABLED` is compared to the string `'true'` in all four places it appears (three workflows plus the pattern guide), never to a boolean. `vars.FACTORY_ALERT_ISSUE` is used identically in `housekeeping.yml` and `ruleset-drift.yml`, with the same unset-guard in both. Ruleset file names (`R1-all-branches.json`, `R2-default-branch.json`) and the `name` fields inside them match the lookups in `apply-rulesets.sh` and `check-drift.sh`, which share one `STRIP` projection so local and CI comparisons cannot diverge. Branch `agent/f0-harden-the-gate` is used consistently in Tasks 9 Steps 2, 4, and the Global Constraints. ADR-0019's filename, its KB README link, the roadmap F0 row, and the in-script `See ADR-0019` reference all agree.

--- a/docs/superpowers/plans/2026-08-01-factory-f2-issue-intake.md
+++ b/docs/superpowers/plans/2026-08-01-factory-f2-issue-intake.md
@@ -1,0 +1,1136 @@
+# Factory F2 — Issue intake, two-phase (`agent:plan` → `agent:go`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the GitHub issue list this repo's work queue. A `agent:plan` label makes an agent hydrate the knowledge base and commit *one* implementation plan to a branch; the maintainer reads it on a phone and may edit it through GitHub's web editor; a `agent:go` label makes an agent implement *that exact file* and open a PR that both `ci.yml` and `claude-code-review.yml` actually run on.
+
+**Architecture:** One workflow file, `.github/workflows/agent-intake.yml`, carrying two jobs on `issues: types: [labeled]`, fanned out on `github.event.label.name` because `label_trigger` takes a single string. Both jobs use `track_progress: true` so the action forces tag mode — restoring GitHub context, the tracking comment, and branch handling — while keeping a custom `prompt`. Every property that matters is enforced by a **non-agent** step: a pre-flight resolves the approved SHA and plan path from git (never from a model-authored comment), and a post-guard runs `git diff --exit-code <approved-sha> -- <plan-path>`. Instructing a model not to re-plan is not a mechanism. `agent:go` opens its PR from *inside* the action step so the App installation token authors it.
+
+**Tech Stack:** GitHub Actions, `anthropics/claude-code-action@v1`, GitHub issue forms (YAML), `gh` CLI, Bash. No application (Java) code changes.
+
+## Global Constraints
+
+- **Depends on F0** ([`2026-08-01-factory-f0-harden-the-gate.md`](2026-08-01-factory-f0-harden-the-gate.md)). Two hard dependencies, not soft ones:
+  - `vars.FACTORY_ENABLED` is introduced by F0. Until it exists and is set to `'true'`, every job here evaluates its `if:` to false and **never runs**. That is the intended fail-closed state, not a bug.
+  - F0's ruleset surgery moves `pull_request{1 approval}` off `~ALL` onto `~DEFAULT_BRANCH`. Until it does, the first **second** push to an existing `agent/issue-<N>` branch is rejected by a PR-required rule on a non-default branch — which is exactly what `agent:go` does after `agent:plan` created it. Do not canary F2 before F0 has merged and been applied.
+- **A green Actions run is not proof of success.** Three green-but-did-nothing incidents are on record in `gotchas.md`. Every guard in this plan asserts an *effect* — a branch exists on the remote at a known SHA, a PR number exists, a diff is empty — never a job's exit status. The canary (Task 6) is falsifiable or it is not done.
+- **Automation may propose but never approve.** No `gh pr merge`, no `gh pr review`, and no Workflows permission appears anywhere in this plan's `--allowedTools`.
+- **Two credential buckets, kept separate** (ADR-0012): everything here runs on `CLAUDE_CODE_OAUTH_TOKEN` (flat-rate seat). `ANTHROPIC_API_KEY` stays scoped to `live-eval.yml`.
+- **Editing `claude-code-review.yml` means the PR carrying this work will not be reviewed by Claude.** The action hard-requires its workflow file to be byte-identical to the default-branch copy and records the mismatch as an *annotation on a successful job* (`gotchas.md`). Expected. Say so in the PR body so it is not later misread as the reviewer silently failing.
+- **Adding a new workflow that contains `claude-code-action` cannot be validated from a branch** for the same reason — the file does not exist on `master` yet, so the action skips itself and the job goes green having done nothing. Only the *non-agent* steps are branch-testable (see Task 3, Step 4). Supplying `github_token:` to bypass the OIDC exchange is the documented escape hatch and is **not** used here: it would author the PR with `GITHUB_TOKEN`, re-triggering the recursion guard this design exists to avoid.
+- Commit messages end with the repo's trailers:
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap`
+- All work lands on a branch off `master` (suggested: `feat/factory-f2-issue-intake`), opened as a PR referencing issue **#75**.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| *(GitHub labels — no file)* | **New.** `agent:plan` and `agent:go`: the state machine. |
+| `.github/ISSUE_TEMPLATE/agent-task.yml` | **New.** Issue form for an agent-workable ticket. None exists today. |
+| `.github/ISSUE_TEMPLATE/config.yml` | **New.** Keep blank issues available; point elsewhere for non-tickets. |
+| `.github/workflows/agent-intake.yml` | **New.** Two jobs, `plan` and `go`, plus every non-agent guard. |
+| `.github/workflows/claude-code-review.yml` | **Modify.** `allowed_bots: 'dependabot'` → `'dependabot,claude'`, in the same commit as the workflow. |
+| `docs/knowledge/roadmap.md` | **Modify (persist).** Redefine plan immutability (2 sites); close the F2 row. |
+| `docs/knowledge/README.md` | **Modify (persist).** Redefine plan immutability; link the new pattern. |
+| `.claude/skills/housekeeping/SKILL.md` | **Modify.** Reconcile its hands-off rule with the new definition. |
+| `docs/knowledge/patterns/agent-issue-intake.md` | **New (persist).** The how-to for driving the two-phase flow. |
+
+---
+
+### Task 1: Create the two state-machine labels
+
+**Files:**
+- None (GitHub repository configuration, applied by the maintainer with `gh`).
+
+**Interfaces:**
+- Produces: labels `agent:plan` and `agent:go`, consumed by `agent-intake.yml`'s `if:` expressions and `label_trigger` inputs (Task 3) and by the issue template's guidance text (Task 2).
+
+The label names are the public contract of this workflow, in the same sense that `@McpTool` names are the public MCP contract. Once a label is in an `if:` expression and a `label_trigger`, renaming it silently stops the state machine — the job's `if:` goes false and the run does not appear at all. Create them exactly as written.
+
+- [ ] **Step 1: Confirm neither label already exists**
+
+Run:
+```bash
+gh label list --limit 100 | grep -E '^agent:' || echo "none"
+```
+Expected: `none`. (Verified at plan time — the repo carries only the nine GitHub defaults plus `dependencies` and `java`.)
+
+- [ ] **Step 2: Create the labels**
+
+Run exactly:
+```bash
+gh label create "agent:plan" \
+  --color "1D76DB" \
+  --description "Phase 1 — agent hydrates the KB and commits an implementation plan to a branch"
+
+gh label create "agent:go" \
+  --color "0E8A16" \
+  --description "Phase 2 — agent implements the approved plan at the branch tip and opens a PR"
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+gh label list --limit 100 | grep -E '^agent:'
+```
+Expected: exactly two lines, `agent:go` and `agent:plan`, with the descriptions above.
+
+- [ ] **Step 4: Commit**
+
+Nothing to commit — labels are repository state, not files. This is deliberate and is the same class of gap F0 names for rulesets: **configuration that is not applied is not configuration.** The compensating control is Task 3's `if:` expression, which simply never matches an absent label, so a missing label fails closed rather than silently running the wrong phase.
+
+---
+
+### Task 2: Add issue templates for agent-workable tickets
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/agent-task.yml`
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+
+**Interfaces:**
+- Produces: an "Agent-workable task" issue form. The body it produces is the *entire* input to the `agent:plan` prompt, which is why the form asks for an outcome and a falsifiable acceptance criterion rather than a free-text wish. The roadmap already names spec quality as the control surface: vague inputs yield confident, wrong output.
+- Consumes: the labels from Task 1 (referenced in guidance text only — deliberately **not** auto-applied; see Step 1).
+
+- [ ] **Step 1: Write the agent-task issue form**
+
+Create `.github/ISSUE_TEMPLATE/agent-task.yml` with exactly this content:
+
+```yaml
+name: Agent-workable task
+description: A task an agent can plan and then implement. Apply the agent:plan label when the ticket reads well.
+title: "<area>: <imperative summary>"
+# `labels:` is deliberately EMPTY. GitHub fires an `issues: labeled` event for labels applied at
+# creation time, so presetting `agent:plan` here would start a planning run the instant the form is
+# submitted — before any human had read the ticket back. The whole premise of two-phase intake is
+# that a human gates each transition. Apply the label by hand, afterwards.
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form's output is the **entire input** to the planning agent. Everything it does not say,
+        the agent will invent. Be concrete.
+
+        **How this ticket moves:**
+        1. Submit it. Read it back. Edit it until it is unambiguous.
+        2. Apply **`agent:plan`** — an agent hydrates `docs/knowledge/` and commits one plan file to
+           `agent/issue-<N>`, then comments with the path and commit SHA.
+        3. Read the plan (a phone is good at this). Edit it in GitHub's web editor if needed; each
+           edit produces a new commit on that branch, and the newest one is what gets implemented.
+        4. Apply **`agent:go`** — the agent implements that file and opens a PR.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What is true after this ships that is not true now? One or two sentences.
+      placeholder: "`lol_match_timeline` returns per-minute gold deltas instead of raw frame blobs."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Falsifiable acceptance criterion
+      description: >-
+        A check that could fail. "It works" is not one. Prefer a command and its expected output.
+      placeholder: |
+        Run: ./gradlew :lol-mcp-server:test --tests '*MatchTimelineServiceTest*'
+        Expected: BUILD SUCCESSFUL, including a new zero-frames case.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: blast-radius
+    attributes:
+      label: Blast radius
+      description: >-
+        Where the change lands. Docs and KB need less ceremony than a library or the tool contract.
+        F5 will turn this into an enforced tier; today it is context for the planner.
+      options:
+        - Docs / knowledge base only
+        - Server module code (lol-mcp-server, tft-mcp-server)
+        - Libraries, MCP tool contract, or workflows
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and non-goals
+      description: >-
+        Anything the agent must not do, and anything adjacent that is explicitly out of scope.
+        The offline suite must stay key-free and network-free; say so again here if it is at risk.
+      placeholder: "Do not change existing @McpTool names or @McpToolParam descriptions."
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant prior art
+      description: >-
+        ADRs, patterns, gotchas, files, or issues the planner should read first. The agent hydrates
+        the knowledge base anyway; this points it at the right corner of it.
+      placeholder: "docs/knowledge/decisions/ADR-0016-bounded-list-results.md; the ordering gotcha."
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Write the template chooser config**
+
+Create `.github/ISSUE_TEMPLATE/config.yml` with exactly this content:
+
+```yaml
+# Blank issues stay available. Not every ticket is agent-workable, and forcing the agent form on a
+# one-line bug report would make the form's own signal worthless.
+blank_issues_enabled: true
+contact_links:
+  - name: Riot API status and endpoint reference
+    url: https://developer.riotgames.com/
+    about: Riot deprecates endpoints without notice. Check the portal before filing an API-shape bug.
+```
+
+- [ ] **Step 3: Lint both files**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/agent-task.yml')); print('ok')"
+python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/config.yml')); print('ok')"
+```
+Expected: `ok` twice.
+
+- [ ] **Step 4: Verify the form renders (after this branch is pushed)**
+
+GitHub only serves issue templates from the **default branch**, so this cannot be checked from a branch. Defer to Task 6, Step 1 — the canary issue is filed through this form, which is the verification. Record here that a schema-valid file that GitHub rejects at render time shows as the template simply not appearing in the chooser.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/agent-task.yml .github/ISSUE_TEMPLATE/config.yml
+git commit -m "feat(intake): add an agent-workable issue form
+
+The form's output is the entire input to the planning agent, so it asks for an
+outcome, a falsifiable acceptance criterion, and a blast radius rather than free
+text. Labels are deliberately not preset: GitHub fires \`labeled\` at creation
+time, which would start a planning run before a human had read the ticket back.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap"
+```
+
+---
+
+### Task 3: Build the two-phase intake workflow, and let the reviewer see its PRs
+
+**Files:**
+- Create: `.github/workflows/agent-intake.yml`
+- Modify: `.github/workflows/claude-code-review.yml` (line 46 — `allowed_bots`)
+
+**Interfaces:**
+- Consumes: labels `agent:plan` / `agent:go` (Task 1); `secrets.CLAUDE_CODE_OAUTH_TOKEN`; `vars.FACTORY_ENABLED` (from F0).
+- Produces: branch `agent/issue-<N>` carrying exactly one plan file; an authoritative issue comment holding the plan path and its commit SHA; and, after `agent:go`, an open PR authored by `claude[bot]` that `ci.yml` and `claude-code-review.yml` both run on.
+
+Three mechanisms in this task are load-bearing and are **not** prompt instructions:
+
+1. **The re-plan guard.** A non-agent step runs `git diff --exit-code "$APPROVED_SHA" -- "$PLAN_PATH"` after the agent step and fails the job if the plan file moved.
+2. **The approved SHA and plan path are derived from git, never read from a comment.** A model-authored SHA can be wrong; `git rev-parse` cannot. The `plan` job's own guard *posts* the comment, so the agent never handles the value it would be judged against.
+3. **PR creation happens inside the action step.** Both reasons are written into the YAML as comments and must survive any later edit.
+
+- [ ] **Step 1: Write the intake workflow**
+
+Create `.github/workflows/agent-intake.yml` with exactly this content:
+
+```yaml
+name: Agent Issue Intake
+
+# The two-phase work queue (sub-project F2). Labels are the state machine, which makes the GitHub
+# issue list the control-plane view and the whole flow operable from a phone:
+#
+#   agent:plan  -> hydrate docs/knowledge/, write ONE plan file, commit + push it to
+#                  agent/issue-<N>. A non-agent step then posts the path and commit SHA.
+#   (maintainer reads the plan on a phone; optional edits via GitHub's web editor land as new
+#    commits on that same branch, producing a new tip SHA — drafts are meant to be edited)
+#   agent:go    -> check out that branch tip, implement THAT plan file, push, and open the PR from
+#                  inside the action step.
+#
+# ONE FILE, TWO JOBS — not two workflow files. `label_trigger` takes a single string, so the two
+# phases cannot share a step; they can share a file, and should:
+#   * gotchas.md records that claude-code-action skips itself (green, as an annotation) whenever its
+#     workflow file differs from the default-branch copy. One file is one byte-identity surface to
+#     keep in sync; two files is two, and the second one drifting is invisible.
+#   * The label vocabulary, the FACTORY_ENABLED kill switch, the human-labeller assertion, the
+#     branch-naming convention and the concurrency group are ONE state machine. Splitting them
+#     across files lets half of it change without the other half.
+#   * Jobs share no state anyway, so two files would buy no isolation to pay for that.
+
+on:
+  issues:
+    types: [labeled]
+
+# Least-privilege default for the workflow; each job elevates only the scopes its steps need.
+permissions:
+  contents: read
+
+# Never let two phases — or a re-labelled issue — race on one issue's branch. Queue rather than
+# cancel: a cancelled run leaves a half-written plan or a half-implemented branch behind, and this
+# repo already learned that a cancelled run satisfies nothing downstream.
+concurrency:
+  group: agent-intake-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------------------------
+  # PHASE 1 — agent:plan
+  # ---------------------------------------------------------------------------------------------
+  plan:
+    name: agent:plan
+    # Three independent gates, all evaluated before any agent starts:
+    #   1. FACTORY_ENABLED — the kill switch introduced by F0. Flipping the repository variable off
+    #      from a mobile browser fails every agent job closed. If the variable does not exist yet,
+    #      this expression is never 'true' and the job never runs: fail-closed by construction.
+    #   2. sender.type == 'User' — asserts a human applied the label. The agent's own `issues: write`
+    #      would otherwise let it label itself into the next phase.
+    #   3. the label name — `label_trigger` takes a single string, so the phase fan-out lives here.
+    if: >-
+      vars.FACTORY_ENABLED == 'true' &&
+      github.event.sender.type == 'User' &&
+      github.event.label.name == 'agent:plan'
+    runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout input of its own; its message loop runs until the job's
+    # timeout kills it. This is the only bound.
+    timeout-minutes: 30
+    permissions:
+      contents: write   # the agent pushes the plan branch from inside its own step
+      issues: write     # tracking comment (track_progress) + the authoritative path/SHA comment
+      id-token: write   # OIDC exchange that mints the action's App installation token
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history: the guards below diff against origin/master with a merge base.
+          fetch-depth: 0
+
+      - name: Prepare the plan branch
+        id: prep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          BRANCH="agent/issue-${ISSUE_NUMBER}"
+
+          # Refuse to re-plan an issue whose implementation has already opened a PR. Re-applying
+          # agent:plan there would rewrite the plan on top of the implementation, and the phase-2
+          # guard would then be comparing against a plan nobody approved.
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "::error title=agent:plan::An open PR already exists for $BRANCH. Implementation has started; close that PR (or open a fresh issue) before re-planning."
+            exit 1
+          fi
+
+          # Reuse the branch if it already exists — a plan still on a branch is a draft and is meant
+          # to be revised. Only a MERGED plan is immutable (see docs/knowledge/README.md).
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::notice title=agent:plan::Reusing existing branch $BRANCH — revising the draft plan."
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Write the implementation plan
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Matches the label this job is gated on. The action's default is 'claude'; leaving it at
+          # the default would make tag mode decline every run here, silently and green.
+          label_trigger: 'agent:plan'
+          # Forces tag mode on the `issues: labeled` event, which restores GitHub context and the
+          # tracking comment while keeping the custom prompt below. Without it, automation mode
+          # gives no visible progress on an issue the maintainer is watching from a phone.
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+            BRANCH: ${{ steps.prep.outputs.branch }}
+
+            You are PHASE 1 of a two-phase intake. You write a plan. You do NOT implement anything.
+
+            1. HYDRATE FIRST, per docs/knowledge/README.md — that file is the single source of truth
+               for the hydrate/persist protocol. Read it, then roadmap.md, then gotchas.md, then the
+               ADRs and patterns/ guides relevant to this issue. Do not skip this because the issue
+               looks small; gotchas.md exists because small-looking things were not.
+
+            2. Write EXACTLY ONE new file:
+                 docs/superpowers/plans/<YYYY-MM-DD>-issue-${{ github.event.issue.number }}-<slug>.md
+               Use today's UTC date and a short kebab-case slug. Match the house style of
+               docs/superpowers/plans/2026-07-19-repo-housekeeping-and-actions.md exactly: the
+               agentic-workers blockquote, Goal / Architecture / Tech Stack, Global Constraints,
+               a File Structure table, `### Task N:` sections separated by `---` with
+               **Files:** / **Interfaces:** / `- [ ] **Step N: ...**` checkboxes, a `Run:` and
+               `Expected:` pair for every verification, a commit step per task carrying both repo
+               trailers, and a closing `## Self-Review`.
+
+               Embed file content verbatim. The implementer should have to invent nothing.
+
+            3. CHANGE NO OTHER FILE. Not source, not docs, not the knowledge base, not workflows.
+               A non-agent step after you enforces this with a git diff and fails the job otherwise;
+               it is a mechanism, not a request. Persisting to the knowledge base is phase 2's job,
+               and your plan should say so.
+
+            4. Commit and push to the branch above, from inside this step:
+                 git add docs/superpowers/plans/
+                 git commit -m "docs(plan): implementation plan for #${{ github.event.issue.number }}"
+                 git push -u origin HEAD:${{ steps.prep.outputs.branch }}
+               Push from HERE. A later step cannot: this action revokes its own git credentials as
+               the step ends (see gotchas.md).
+
+            5. Do NOT post the plan path or commit SHA yourself. A non-agent step reads both from
+               git and posts them, because a SHA the maintainer approves must come from git rather
+               than from a model's recollection of what it just did.
+          claude_args: |
+            --max-turns 60
+            --allowedTools "Read,Write,Grep,Glob,Bash(ls:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh issue view:*)"
+
+      # ---- Non-agent guard. Everything below asserts an EFFECT, never the job's exit status. ----
+      - name: Assert the plan landed, and landed alone
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.prep.outputs.branch }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          CHANGED="$(git diff --name-only origin/master...HEAD)"
+          COUNT="$(printf '%s\n' "$CHANGED" | grep -c . || true)"
+
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error title=agent:plan::Expected exactly 1 changed file, found $COUNT:"
+            printf '%s\n' "$CHANGED"
+            exit 1
+          fi
+
+          PLAN_PATH="$CHANGED"
+          case "$PLAN_PATH" in
+            docs/superpowers/plans/*.md) : ;;
+            *)
+              echo "::error title=agent:plan::The changed file is not a plan: $PLAN_PATH"
+              exit 1
+              ;;
+          esac
+
+          # A commit that was never pushed is the classic green-but-did-nothing shape: the local
+          # diff looks perfect and the maintainer has nothing to read. Compare local HEAD against
+          # what the remote actually holds.
+          git fetch origin "$BRANCH"
+          LOCAL_SHA="$(git rev-parse HEAD)"
+          REMOTE_SHA="$(git rev-parse FETCH_HEAD)"
+          if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+            echo "::error title=agent:plan::HEAD ($LOCAL_SHA) was not pushed to $BRANCH (remote is $REMOTE_SHA)."
+            exit 1
+          fi
+
+          # The authoritative comment. Read from git, posted by a non-agent step, so the SHA the
+          # maintainer approves is the SHA that exists.
+          #
+          # Built with printf rather than a heredoc on purpose: this whole script is a YAML block
+          # scalar, every line is indented, and an unquoted heredoc terminator must sit at column 0
+          # of its line. `<<-EOF` only strips TABS, which YAML forbids as indentation. printf sidesteps
+          # the entire problem.
+          BODY="$(printf '%s\n' \
+            "### Plan ready for review" \
+            "" \
+            "| | |" \
+            "|---|---|" \
+            "| **Plan** | [\`$PLAN_PATH\`](../blob/$REMOTE_SHA/$PLAN_PATH) |" \
+            "| **Branch** | \`$BRANCH\` |" \
+            "| **Commit** | \`$REMOTE_SHA\` |" \
+            "" \
+            "Read it, and edit it in the web editor if it needs changing — a draft plan on a branch" \
+            "is meant to be revised, and each edit becomes a new commit here. When it reads right," \
+            "apply the **\`agent:go\`** label; phase 2 implements whatever is at this branch's tip at" \
+            "that moment, and fails the job if it drifts afterwards.")"
+
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+
+  # ---------------------------------------------------------------------------------------------
+  # PHASE 2 — agent:go
+  # ---------------------------------------------------------------------------------------------
+  go:
+    name: agent:go
+    if: >-
+      vars.FACTORY_ENABLED == 'true' &&
+      github.event.sender.type == 'User' &&
+      github.event.label.name == 'agent:go'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write        # push implementation commits from inside the action step
+      issues: write          # tracking comment + failure escalation
+      pull-requests: write   # `gh pr create` inside the action step needs this on the minted token
+      id-token: write
+    steps:
+      - name: Checkout the approved branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/issue-${{ github.event.issue.number }}
+          fetch-depth: 0
+
+      - name: Resolve the approved SHA and plan path
+        id: approved
+        run: |
+          set -euo pipefail
+          BRANCH="agent/issue-${{ github.event.issue.number }}"
+
+          # The approved artifact is the branch tip AT THIS MOMENT — including any web-editor edits
+          # the maintainer made. Resolved from git, never parsed out of an issue comment.
+          APPROVED_SHA="$(git rev-parse HEAD)"
+
+          CHANGED="$(git diff --name-only origin/master...HEAD)"
+          COUNT="$(printf '%s\n' "$CHANGED" | grep -c . || true)"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error title=agent:go::Expected the branch to carry exactly 1 plan file vs master, found $COUNT:"
+            printf '%s\n' "$CHANGED"
+            exit 1
+          fi
+
+          PLAN_PATH="$CHANGED"
+          case "$PLAN_PATH" in
+            docs/superpowers/plans/*.md) : ;;
+            *)
+              echo "::error title=agent:go::The branch's only change is not a plan: $PLAN_PATH"
+              exit 1
+              ;;
+          esac
+
+          echo "branch=$BRANCH"             >> "$GITHUB_OUTPUT"
+          echo "sha=$APPROVED_SHA"          >> "$GITHUB_OUTPUT"
+          echo "plan_path=$PLAN_PATH"       >> "$GITHUB_OUTPUT"
+          echo "::notice title=agent:go::Implementing $PLAN_PATH at $APPROVED_SHA"
+
+      - name: Implement the approved plan
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          label_trigger: 'agent:go'
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            APPROVED PLAN: ${{ steps.approved.outputs.plan_path }}
+            APPROVED SHA: ${{ steps.approved.outputs.sha }}
+            BRANCH: ${{ steps.approved.outputs.branch }}
+
+            You are PHASE 2. The plan above has been read and approved by a human. Implement it.
+
+            1. Read the approved plan file first, in full. It is the specification. Hydrate the
+               knowledge base per docs/knowledge/README.md for anything the plan assumes.
+
+            2. Work the plan task by task, in order, honouring its verification steps.
+
+            3. DO NOT EDIT THE APPROVED PLAN FILE. Not to tick its checkboxes, not to correct it,
+               not to reflect what you actually did. A non-agent step after you runs
+               `git diff --exit-code ${{ steps.approved.outputs.sha }} -- ${{ steps.approved.outputs.plan_path }}`
+               and fails this job if it moved. If the plan turns out to be wrong, implement what you
+               can, and describe the deviation in the PR body — deviations belong in the PR, and
+               architectural ones become ADRs.
+
+            4. Keep the offline gate green: `./gradlew build` must pass, with no test that needs a
+               live Riot key or network access. Persist findings per the knowledge-base protocol if
+               the plan calls for it.
+
+            5. Commit, push, and OPEN THE PULL REQUEST FROM INSIDE THIS STEP:
+                 git add -A
+                 git commit -m "<type>(<scope>): <summary>" \
+                   -m "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+                 git push origin HEAD:${{ steps.approved.outputs.branch }}
+                 gh pr create --base master --head ${{ steps.approved.outputs.branch }} \
+                   --title "<type>(<scope>): <summary>" \
+                   --body "Implements ${{ steps.approved.outputs.plan_path }} at commit ${{ steps.approved.outputs.sha }}. Closes #${{ github.event.issue.number }}. <deviations, if any>"
+
+               It MUST happen here, in this step, for two independent reasons — both structural:
+                 (a) This step's credential is the action's own GitHub App installation token. App
+                     tokens are NOT subject to the GITHUB_TOKEN recursion guard, so the resulting PR
+                     actually fires `pull_request` events: ci.yml's `Build & verify` reports, and
+                     claude-code-review.yml runs. Opened with GITHUB_TOKEN instead, the PR would get
+                     neither — and with `Build & verify` a required check, a check that never
+                     reports makes the PR permanently unmergeable, not merely unreviewed.
+                 (b) This action revokes its installation token as this step ends. A later step in
+                     this job has no working git credential at all (gotchas.md). Inside is the only
+                     place both credentials exist.
+
+            6. NEVER merge, approve, or request-review-dismissal on the PR. Automation proposes;
+               a human approves. That is not negotiable and no tool here grants it.
+          claude_args: |
+            --max-turns 150
+            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(./gradlew:*),Bash(ls:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh issue view:*),Bash(gh pr create:*),Bash(gh pr view:*)"
+
+      # ---- The re-plan guard. Deterministic, non-agent, and the reason this design works. ----
+      - name: Re-plan guard — the approved plan must not have moved
+        env:
+          APPROVED_SHA: ${{ steps.approved.outputs.sha }}
+          PLAN_PATH: ${{ steps.approved.outputs.plan_path }}
+        run: |
+          set -euo pipefail
+          if ! git diff --exit-code "$APPROVED_SHA" -- "$PLAN_PATH"; then
+            echo "::error title=agent:go::$PLAN_PATH differs from the approved commit $APPROVED_SHA. The approval bound to an artifact and the artifact changed. Close the PR and re-review."
+            exit 1
+          fi
+          echo "::notice title=agent:go::Approved plan unchanged at $APPROVED_SHA."
+
+      - name: Assert a pull request actually exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.approved.outputs.branch }}
+        run: |
+          set -euo pipefail
+          PR="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$PR" ]; then
+            echo "::error title=agent:go::No open PR for $BRANCH. The agent step exited without proposing anything — a green run here would have been the third green-but-did-nothing incident on record."
+            exit 1
+          fi
+          echo "::notice title=agent:go::Opened PR #$PR."
+
+  # ---------------------------------------------------------------------------------------------
+  # Escalation. GitHub pushes @mention notifications to GitHub Mobile; workflow-failure email does
+  # not cover `issues`-triggered runs, so a silent red run is a run nobody learns about.
+  # ---------------------------------------------------------------------------------------------
+  alert:
+    name: Escalate a failed phase
+    needs: [plan, go]
+    if: always() && (needs.plan.result == 'failure' || needs.go.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Comment on the issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --body "@Muddl the \`${{ github.event.label.name }}\` phase failed. [Run log](${RUN_URL}). Nothing was merged; the kill switch is \`FACTORY_ENABLED\`."
+```
+
+- [ ] **Step 2: Let the reviewer see `claude[bot]` PRs**
+
+In `.github/workflows/claude-code-review.yml`, change line 46 from:
+```yaml
+          allowed_bots: 'dependabot'
+```
+to:
+```yaml
+          # `claude` is here because agent:go opens its PR with the action's own App installation
+          # token, making claude[bot] the PR author. The action declines bot-triggered runs unless
+          # the bot is listed — and it declines by going GREEN, so without this the agent's own PR
+          # would sail past the reviewer looking reviewed. That is ADR-0018's failure shape exactly:
+          # artifact present, property absent.
+          allowed_bots: 'dependabot,claude'
+```
+
+The bot login is asserted, not assumed: `dependabot` is listed without its `[bot]` suffix, so the action compares the stripped login. Task 6, Step 4 is the falsification — if the reviewer does not run on the canary PR, read `github.event.pull_request.user.login` from the PR and use that string verbatim here.
+
+- [ ] **Step 3: Lint both workflows**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/agent-intake.yml')); print('ok')"
+python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml')); print('ok')"
+```
+Expected: `ok` twice.
+
+- [ ] **Step 4: Statically verify the guard logic, since the workflow itself is not branch-testable**
+
+`gotchas.md`: `claude-code-action` refuses to run when its workflow file differs from the default-branch copy — and `agent-intake.yml` does not exist on `master` at all, so a branch dispatch would skip both agent steps and go **green having done nothing**. Only the non-agent steps can be checked here, and they can be checked directly:
+
+```bash
+# The phase-1 shape check, replayed against this very branch (which has >1 changed file, so it
+# must reject) and against a synthetic single-plan case (which must accept).
+git diff --name-only origin/master...HEAD | grep -c .
+```
+Expected: an integer **greater than 1** — proving the phase-1 guard would correctly reject a branch that touched more than the plan. (The single-file accept path is exercised for real by Task 6, Step 2.)
+
+```bash
+# The re-plan guard, replayed locally: identical content passes, a byte changed fails.
+BASE="$(git rev-parse HEAD)"
+git diff --exit-code "$BASE" -- docs/superpowers/plans/ && echo "GUARD-PASS"
+printf '\n' >> docs/superpowers/plans/2026-08-01-factory-f2-issue-intake.md
+git diff --exit-code "$BASE" -- docs/superpowers/plans/ || echo "GUARD-FAIL-AS-EXPECTED"
+git checkout -- docs/superpowers/plans/2026-08-01-factory-f2-issue-intake.md
+```
+Expected: `GUARD-PASS` then `GUARD-FAIL-AS-EXPECTED`. This is the mechanism of the whole design, verified with no tokens spent and no reliance on a green run.
+
+- [ ] **Step 5: Commit — both files together**
+
+The `allowed_bots` change ships in the same commit as the workflow on purpose: a commit that adds `agent:go` without it produces PRs that go unreviewed on a green run, and that is a state this repo should never be in for even one commit.
+
+```bash
+git add .github/workflows/agent-intake.yml .github/workflows/claude-code-review.yml
+git commit -m "feat(intake): two-phase agent issue intake, guarded deterministically
+
+agent:plan commits one plan file to agent/issue-<N>; a non-agent step reads the
+path and tip SHA from git and posts them. agent:go checks that branch out,
+implements that file, and opens the PR from inside the action step so the App
+installation token authors it — App tokens escape the GITHUB_TOKEN recursion
+guard, so pull_request fires and Build & verify actually reports, and inside the
+step is the only place the action's git credential is still alive.
+
+A non-agent step then runs git diff --exit-code <approved-sha> -- <plan-path>.
+Instructing the model not to re-plan is not a mechanism.
+
+allowed_bots gains 'claude' in this same commit: the agent's PR is authored by
+claude[bot], and the reviewer declines unlisted bots by going green.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap"
+```
+
+---
+
+### Task 4: Redefine plan immutability as "immutable once merged to `master`"
+
+**Files:**
+- Modify: `docs/knowledge/roadmap.md` (2 sites)
+- Modify: `docs/knowledge/README.md` (the Persist section)
+- Modify: `.claude/skills/housekeeping/SKILL.md` (the Hands-off section)
+
+**Interfaces:**
+- Produces: a rule the `agent:plan` review phase can satisfy. The current rule cannot survive a phase whose entire purpose is refining a plan before approval — under it, the maintainer's web-editor edit is a violation.
+- Consumes: nothing. Blocks nothing. But leaving it stale means the flow shipped in Task 3 contradicts the knowledge base on its first run.
+
+- [ ] **Step 1: Find every site the rule is stated**
+
+Run:
+```bash
+grep -rniE "immutable|dated snapshot|not edited retroactively" \
+  --include='*.md' docs/knowledge .claude CLAUDE.md CONTRIBUTING.md README.md
+```
+Expected: at minimum these four sites, which are the ones this task edits —
+`docs/knowledge/roadmap.md:8`, `docs/knowledge/roadmap.md:193`, `docs/knowledge/README.md:77`,
+`.claude/skills/housekeeping/SKILL.md:48`. Hits inside `docs/superpowers/specs/` and
+`docs/superpowers/plans/` are **not** edited: those files are merged history, which is the very rule
+being restated. If the grep surfaces a fifth live site, fix it the same way and note it in the PR.
+
+- [ ] **Step 2: Redefine the rule in `roadmap.md`'s preamble**
+
+In `docs/knowledge/roadmap.md`, replace:
+```markdown
+This file is the **source of truth for scope and sequencing**. Specs under
+`docs/superpowers/specs/` are dated snapshots of a decision at a moment — they are history and are
+not edited retroactively. When scope moves, it moves here.
+```
+with:
+```markdown
+This file is the **source of truth for scope and sequencing**. Specs under
+`docs/superpowers/specs/` are dated snapshots of a decision at a moment — they are history and are
+not edited retroactively. Plans under `docs/superpowers/plans/` are history **once merged to
+`master`**; a plan still on an `agent/issue-<N>` branch is a draft and is meant to be edited, which
+is exactly what the `agent:plan` review phase exists to do. When scope moves, it moves here.
+```
+
+- [ ] **Step 3: Fix the Replayability row**
+
+In `docs/knowledge/roadmap.md`, in the "Substrate already in place" table, replace:
+```markdown
+| Replayability | ADRs + immutable `docs/superpowers/specs|plans/` record why a change looks the way it does |
+```
+with:
+```markdown
+| Replayability | ADRs + `docs/superpowers/specs/` and **merged** `docs/superpowers/plans/` record why a change looks the way it does |
+```
+
+- [ ] **Step 4: State the rule where the protocol lives**
+
+`docs/knowledge/README.md` is the single source of truth for the hydrate/persist protocol, so the rule belongs there in full. In its **Persist** section, immediately after the `roadmap.md` bullet and immediately before the line beginning `Do not edit an existing ADR`, insert:
+
+```markdown
+**Plans are immutable once merged to `master`.** A plan under `docs/superpowers/plans/` is a *draft*
+while it lives on a branch — the two-phase `agent:plan` → `agent:go` intake exists precisely so a
+plan can be refined before it is approved, and the maintainer's web-editor edits are the expected
+path, not an exception. Once merged it is history: never edited, never re-ticked, never corrected
+after the fact. Deviations discovered during implementation are recorded in the implementing PR's
+body, and architectural ones become ADRs. See
+[the issue-intake pattern](patterns/agent-issue-intake.md).
+
+```
+
+- [ ] **Step 5: Reconcile the housekeeping skill's hands-off rule**
+
+The skill must not be left saying something the KB no longer says. In `.claude/skills/housekeeping/SKILL.md`, replace:
+```markdown
+## Hands-off (never touch)
+
+`docs/superpowers/specs/` and `docs/superpowers/plans/` are dated snapshots — immutable history.
+Do not edit or trim them. Scope moves in `roadmap.md`, not in the dated specs.
+```
+with:
+```markdown
+## Hands-off (never touch)
+
+`docs/superpowers/specs/` and merged `docs/superpowers/plans/` are dated snapshots — immutable
+history. Do not edit or trim them. Scope moves in `roadmap.md`, not in the dated specs.
+
+A plan that has **not** merged to `master` is a draft and is editable (see the KB README). This
+skill never encounters one: housekeeping runs from `master`, where every plan present is merged. So
+in practice the rule above is unchanged for this skill — it is restated only so the skill and the
+knowledge base cannot be read as disagreeing.
+```
+
+- [ ] **Step 6: Verify no live site still states the old rule**
+
+Run:
+```bash
+grep -rn "immutable \`docs/superpowers/specs|plans/\`" --include='*.md' . ; \
+grep -rniE "plans/\` are dated snapshots — immutable" --include='*.md' docs/knowledge .claude
+```
+Expected: no output from the first grep; from the second, no hits outside `docs/superpowers/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/knowledge/roadmap.md docs/knowledge/README.md .claude/skills/housekeeping/SKILL.md
+git commit -m "docs(kb): plans are immutable once merged, not once written
+
+The old rule cannot survive a review phase whose entire purpose is refining a
+plan before approval — under it, the maintainer's web-editor edit during
+agent:plan is a violation. Drafts on a branch are mutable; merged plans are
+history, with deviations recorded in the implementing PR body and architectural
+ones becoming ADRs.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap"
+```
+
+---
+
+### Task 5: Persist the intake flow as a knowledge-base pattern
+
+**Files:**
+- Create: `docs/knowledge/patterns/agent-issue-intake.md`
+- Modify: `docs/knowledge/README.md` (Patterns list)
+- Modify: `docs/knowledge/roadmap.md` (the F2 row)
+
+**Interfaces:**
+- Consumes: everything built in Tasks 1–4.
+- Produces: the repeatable procedure, per the persist half of the protocol in `docs/knowledge/README.md` — "Established a new recurring procedure? Add a new guide in `patterns/`, then link it from this README's Patterns list."
+
+No ADR is written for F2. The architectural decision is already recorded in the merged
+[2026-08-01 decomposition spec](../../superpowers/specs/2026-08-01-software-factory-decomposition-design.md),
+and the next free ADR number is contended right now: F0 ships concurrently and may claim it. A
+duplicate ADR number is worse than a missing one. If F2 later needs its own ADR, allocate the number
+after F0 has merged.
+
+- [ ] **Step 1: Write the pattern guide**
+
+Create `docs/knowledge/patterns/agent-issue-intake.md` with exactly this content. **The outer fence
+below is four backticks** because the guide itself contains a three-backtick block; write the file
+with the inner three-backtick fences intact and no four-backtick fence at all.
+
+````markdown
+# Drive an issue through two-phase agent intake
+
+The GitHub issue list is this repo's work queue, and labels are its state machine — which is what
+makes it operable from a phone. `.github/workflows/agent-intake.yml` implements it. Sub-project F2;
+see the [decomposition spec](../../superpowers/specs/2026-08-01-software-factory-decomposition-design.md).
+
+## The flow
+
+| Step | Who | What happens |
+|---|---|---|
+| 1 | Human | File the issue (the **Agent-workable task** form). Read it back; edit until unambiguous. |
+| 2 | Human | Apply **`agent:plan`**. |
+| 3 | Agent | Hydrates `docs/knowledge/`, writes **one** plan file, commits and pushes `agent/issue-<N>`. |
+| 4 | Workflow | A non-agent step asserts exactly one changed file, asserts it reached the remote, and comments the path + tip SHA. |
+| 5 | Human | Read the plan. Edit it in the web editor if needed — each edit is a new commit, and the newest tip is what gets built. |
+| 6 | Human | Apply **`agent:go`**. |
+| 7 | Agent | Checks out that tip, implements that file, pushes, and opens the PR **from inside the action step**. |
+| 8 | Workflow | `git diff --exit-code <approved-sha> -- <plan-path>` fails the job if the plan moved; a second step fails it if no PR exists. |
+| 9 | Human | Review the PR. Approve and merge, or don't. Automation never does this step. |
+
+## Why each mechanism is shaped the way it is
+
+- **The approval binds to an artifact, not a conversation.** The approved SHA is `git rev-parse HEAD`
+  on the branch at the moment `agent:go` is applied — resolved by a non-agent step, never parsed out
+  of a comment a model wrote. A SHA a model reports can be wrong; a SHA git reports cannot.
+- **The re-plan guard is a diff, not an instruction.** The prompt also tells the agent not to touch
+  the plan, but that is courtesy. The mechanism is
+  `git diff --exit-code "$APPROVED_SHA" -- "$PLAN_PATH"`.
+- **The PR is opened inside the action step.** Twice load-bearing. App installation tokens are not
+  subject to the `GITHUB_TOKEN` recursion guard, so `pull_request` fires and `Build & verify`
+  reports — and since that is a required check, a PR it never reports on is permanently unmergeable,
+  not merely unreviewed. And the action revokes its own git credentials as the step ends
+  ([gotchas.md](../gotchas.md)), so inside the step is the only place a working credential exists.
+- **`allowed_bots` includes `claude`.** The PR's author is `claude[bot]`, and
+  `claude-code-review.yml` declines unlisted bots by going *green*. Omitting it reproduces ADR-0018's
+  failure exactly: artifact present, property absent.
+- **`track_progress: true`.** Forces tag mode on the `issues: labeled` event, restoring GitHub
+  context and the tracking comment while keeping the custom `prompt`. Without it there is no visible
+  progress on an issue someone is watching from a phone.
+- **`sender.type == 'User'`.** The agent holds `issues: write`; without this it could label itself
+  into the next phase.
+
+## Operating it
+
+```bash
+gh issue create --title "docs: ..." --body "..."     # or use the issue form in the web UI
+gh issue edit <N> --add-label "agent:plan"
+gh issue view <N> --comments                          # read the plan path + SHA
+gh issue edit <N> --add-label "agent:go"
+gh pr checks <branch-or-pr>                           # ci.yml AND claude-code-review.yml must appear
+```
+
+## When it goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| No run appears at all | `FACTORY_ENABLED` is not `'true'`, a bot applied the label, or the label name does not match | Check the repo variable; check `sender.type`; labels are `agent:plan` / `agent:go` exactly |
+| `Expected exactly 1 changed file, found N` | The planning agent edited something besides its plan | Read the listed paths; re-plan on a clean branch |
+| `HEAD was not pushed` | The agent committed but never pushed | Re-apply `agent:plan`; the branch is reused and the draft revised |
+| `differs from the approved commit` | The implementing agent rewrote the plan | Close the PR. The approval is void — the artifact it bound to no longer exists |
+| `No open PR for <branch>` | The agent step ended without proposing anything | Read the run log; this is the failure a green run would otherwise have hidden |
+| Reviewer never runs on the agent's PR | Wrong bot login in `allowed_bots` | Read `github.event.pull_request.user.login` on the PR and use it verbatim |
+| An open PR blocks re-planning | Implementation already started on that branch | Close the PR, or open a fresh issue |
+
+## Kill switch
+
+Set the repository variable `FACTORY_ENABLED` to anything but `true` and every agent job stops
+matching its `if:`. Escalating further: disable the workflow from the Actions tab, then revoke
+`CLAUDE_CODE_OAUTH_TOKEN`. All three are reachable from a mobile browser.
+````
+
+- [ ] **Step 2: Link the pattern from the KB README**
+
+In `docs/knowledge/README.md`, in the **Patterns** list, immediately after the `Run and extend the live eval harness` item, add:
+```markdown
+- [Drive an issue through two-phase agent intake](patterns/agent-issue-intake.md)
+```
+
+- [ ] **Step 3: Close the roadmap's F2 row**
+
+In `docs/knowledge/roadmap.md`, in the six-sub-project table, replace:
+```markdown
+| **F2** | Issue intake, two-phase | ⏳ Not started | `agent:plan` commits a plan and posts its SHA; `agent:go` implements *that SHA*, checked by a deterministic `git diff --exit-code`. The work-queue primitive. |
+```
+with:
+```markdown
+| **F2** | Issue intake, two-phase | ✅ Shipped | `.github/workflows/agent-intake.yml` + the [intake pattern](patterns/agent-issue-intake.md). `agent:plan` commits a plan and a non-agent step posts its SHA; `agent:go` implements *that SHA*, checked by `git diff --exit-code`. The work-queue primitive. |
+```
+
+Also update the primitives-audit row above it, replacing:
+```markdown
+| **Work queue** — issues, assigned | ⏳ Issues are not yet the intake path. This is the next real step. |
+```
+with:
+```markdown
+| **Work queue** — issues, assigned | ✅ Issues are the intake path: `agent:plan` / `agent:go` labels drive [`agent-intake.yml`](../../.github/workflows/agent-intake.yml). See the [intake pattern](patterns/agent-issue-intake.md). |
+```
+
+- [ ] **Step 4: Verify every pattern on disk is linked**
+
+Run:
+```bash
+comm -23 \
+  <(ls docs/knowledge/patterns/*.md | xargs -n1 basename | sort) \
+  <(grep -oE 'patterns/[a-z0-9-]+\.md' docs/knowledge/README.md | sed 's|patterns/||' | sort -u)
+```
+Expected: empty output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/knowledge/patterns/agent-issue-intake.md docs/knowledge/README.md docs/knowledge/roadmap.md
+git commit -m "docs(kb): pattern for two-phase agent issue intake; close F2
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap"
+```
+
+---
+
+### Task 6: Canary the whole flow end to end, watched
+
+**Files:** none (integration/verification task)
+
+**Interfaces:**
+- Consumes: Tasks 1–5, **merged to `master`**. Nothing below can be run from a branch.
+- Produces: the only evidence that any of this works.
+
+**This workflow's first real execution is necessarily its first test.** There is no staging issue
+list and no dry-run mode. Two facts make branch-based rehearsal impossible, not merely inconvenient:
+
+1. `claude-code-action` refuses to run when its workflow file differs from the default-branch copy,
+   and records the refusal as an **annotation on a successful job**. `agent-intake.yml` does not
+   exist on `master` until this PR merges, so any branch dispatch skips both agent steps and reports
+   green. A new workflow containing the action **cannot be validated from a branch** unless
+   `github_token:` is supplied to bypass the OIDC exchange — which this design specifically must not
+   do, because a `GITHUB_TOKEN`-authored PR re-triggers the recursion guard the whole `gh pr create`
+   placement exists to escape.
+2. GitHub serves issue templates only from the default branch, so the form in Task 2 is likewise
+   unverifiable until merge.
+
+Therefore: merge first, then run the canary **at a desk, watching**, before any real ticket is
+labelled. Do not do this while unreachable.
+
+Prerequisites, checked before starting: F0 is merged and applied (`FACTORY_ENABLED` exists and is
+`'true'`; the ruleset split has been applied locally by the maintainer), and this PR is merged.
+
+- [ ] **Step 1: File a deliberately trivial canary issue through the form**
+
+In the web UI, choose **Agent-workable task**. Make it small enough that a wrong plan costs nothing
+and a right one is unmistakable — e.g. *"docs: add a one-line glossary entry for `puuid`"*, blast
+radius **Docs / knowledge base only**, acceptance criterion
+`grep -c '^## puuid' docs/knowledge/glossary.md` → `1`.
+
+Run: `gh issue list --limit 3`
+**Falsifiable criterion:** the issue exists **and** the form appeared in the chooser with its three
+required fields. If the form did not appear, Task 2's YAML is schema-valid but GitHub-invalid — stop
+and fix it; nothing downstream is meaningful.
+
+- [ ] **Step 2: Phase 1 — `agent:plan`**
+
+```bash
+gh issue edit <N> --add-label "agent:plan"
+gh run watch "$(gh run list --workflow=agent-intake.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh issue view <N> --comments
+```
+**Falsifiable criteria, all four required:**
+1. A run appears at all — proving `FACTORY_ENABLED`, `sender.type`, and the label name all matched.
+   *No run* is the most likely first failure and is silent by nature.
+2. The final comment names a path under `docs/superpowers/plans/` and a 40-character SHA.
+3. `git fetch origin agent/issue-<N> && git rev-parse FETCH_HEAD` equals that SHA exactly.
+4. `git diff --name-only origin/master...FETCH_HEAD` prints **exactly one line**, that path.
+
+If (2) is present but (3) disagrees, the guard is broken, not the agent — that comment is posted by
+a non-agent step *from* `git rev-parse`, so a mismatch means the wrong ref was read.
+
+- [ ] **Step 3: Prove tampering fails the job — do this BEFORE the honest run**
+
+Test the guard on a run you are willing to lose. Edit the plan file on the branch through GitHub's
+web editor (add a trailing blank line — content is irrelevant), then note the branch tip **before**
+labelling, then have a second edit land after the run starts. The simplest deterministic version:
+
+```bash
+# Capture the approved SHA, apply agent:go, then immediately push a change to the plan file so it
+# moves out from under the running job.
+git fetch origin "agent/issue-<N>"
+APPROVED="$(git rev-parse FETCH_HEAD)"; echo "$APPROVED"
+gh issue edit <N> --add-label "agent:go"
+# ...then, while the run is in flight, edit the plan file in the GitHub web editor and commit.
+gh run watch "$(gh run list --workflow=agent-intake.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+**Falsifiable criterion:** the `go` job's conclusion is **failure**, and the failing step is
+`Re-plan guard — the approved plan must not have moved`, with the annotation naming
+`$APPROVED`. A failure in any *other* step does not count — it would mean the job died before the
+guard ever ran, proving nothing about the guard.
+
+Note the honest consequence of mechanism (3): because the PR is opened *inside* the agent step, the
+guard runs after it. A tampered run therefore leaves an open PR behind, failing loudly on the
+**issue**, not on the PR. Close that PR by hand and record that you did. This trade-off is inherent
+to opening the PR with the App token and is accepted, not overlooked.
+
+Then reset for the honest run:
+```bash
+gh pr close <tampered-pr>
+gh issue edit <N> --remove-label "agent:go"
+```
+(If the branch is now polluted, delete it and re-run Step 2.)
+
+- [ ] **Step 4: Phase 2 — the honest `agent:go`, and the check that everything actually reports**
+
+```bash
+gh issue edit <N> --add-label "agent:go"
+gh run watch "$(gh run list --workflow=agent-intake.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+PR="$(gh pr list --head "agent/issue-<N>" --state open --json number --jq '.[0].number')"; echo "$PR"
+gh pr view "$PR" --json author,headRefName --jq '{author: .author.login, head: .headRefName}'
+gh pr checks "$PR"
+```
+**Falsifiable criteria, all five required:**
+1. The `go` job's conclusion is **success**.
+2. `$PR` is non-empty — a PR exists. (The workflow's own `Assert a pull request actually exists`
+   step covers this, but check it independently; that is the point of an external criterion.)
+3. `author.login` is a bot identity, **not** `Muddl` and not `github-actions`. Record the exact
+   string — Task 3, Step 2's `allowed_bots` value must match it with `[bot]` stripped.
+4. `gh pr checks "$PR"` lists a row for **`Build & verify`** with a real conclusion. A PR with *no*
+   row for it is the permanently-unmergeable failure the App-token placement exists to prevent, and
+   it looks fine until someone tries to merge.
+5. `gh pr checks "$PR"` also lists **`Claude Code Review`**, and `gh pr view "$PR" --comments` shows
+   an actual review comment. A green `Claude Code Review` run with no comment means the bot login
+   in `allowed_bots` is wrong — the action declines unlisted bots *green*. Fix the string, push, and
+   re-verify; a green run is not the evidence here, the comment is.
+
+- [ ] **Step 5: Confirm automation proposed and did not approve**
+
+Run:
+```bash
+gh pr view "$PR" --json reviews,mergedAt --jq '{reviews: [.reviews[].author.login], merged: .mergedAt}'
+```
+**Falsifiable criterion:** `merged` is `null`, and no review is an APPROVED review from a machine
+identity. Then merge it by hand — or close it, since the canary's content is disposable. Either way
+the human did it.
+
+- [ ] **Step 6: Exercise the kill switch from the phone**
+
+From GitHub Mobile or a mobile browser, set `FACTORY_ENABLED` to `false`, apply `agent:plan` to a
+throwaway issue, and confirm **no run appears** in the Actions tab. Set it back to `true`.
+
+**Falsifiable criterion:** `gh run list --workflow=agent-intake.yml --limit 3` shows no new run for
+that issue. "No run" is the correct observation and is easy to mistake for "I did not look hard
+enough" — check the timestamps.
+
+- [ ] **Step 7: Record the canary in the pattern guide if anything surprised you**
+
+If any criterion above failed on the first attempt, append the symptom and cause to the pattern's
+"When it goes wrong" table (or to `docs/knowledge/gotchas.md` if it is a sharp edge rather than an
+operating error), and commit with both trailers. A canary that taught nothing needs no entry; one
+that did must not lose it.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `### 3. F2` of the decomposition spec, and issue #75):
+- `agent:plan` hydrates the KB per the repo protocol, writes a plan, commits it to a branch, and the path + SHA are posted → Task 3, `plan` job. Strengthened past the spec: the comment is posted by a **non-agent** step reading `git rev-parse`, so the SHA the maintainer approves cannot be a model's recollection. ✅
+- "Touches no other file" enforced, not requested → Task 3, `Assert the plan landed, and landed alone`. ✅
+- Maintainer reads on a phone, edits via the web editor producing a new SHA, then applies `agent:go` → Task 3 (`Resolve the approved SHA` reads the tip at label time, so web edits are picked up by construction), documented in Task 5's pattern. ✅
+- `agent:go` checks out the approved SHA and implements *that file* → Task 3, `go` job, `ref: agent/issue-<N>` + `Resolve the approved SHA`. ✅
+- **Deterministic re-plan guard**, non-agent, `git diff --exit-code <sha> -- <path>` → Task 3, `Re-plan guard`; rehearsed locally in Task 3 Step 4; falsified live in Task 6 Step 3. ✅
+- **PR created inside the action step** via `Bash(gh pr create:*)` on the App installation token, with **both** reasons written as YAML comments (recursion-guard/required-check, and credential revocation) → Task 3, Step 1, prompt item 5(a)/(b). ✅
+- **`claude` added to `allowed_bots`, in the same commit** → Task 3, Steps 2 and 5. ✅
+- `on: issues: types: [labeled]`; two jobs gated on `github.event.label.name`, **with the one-file-vs-two-files choice justified** → Task 3, Step 1 header comment (byte-identity surface, one state machine, no isolation gained). ✅
+- `track_progress: true` → both jobs. ✅
+- `--max-turns` explicit (60 / 150) and job `timeout-minutes` (30 / 90 / 5) → Task 3. ✅
+- `if: vars.FACTORY_ENABLED == 'true'`, with the F0 dependency noted → Global Constraints + both jobs' `if:`. ✅
+- `github.event.sender.type == 'User'` → both jobs' `if:`. ✅
+- `--allowedTools` least-privilege and explicit → Task 3; phase 1 has no `Edit`, no `gh issue comment`, no `./gradlew`; neither phase has `gh pr merge`, `gh pr review`, or any Workflows scope. ✅
+- Labels created with exact commands → Task 1. ✅
+- Issue templates under `.github/ISSUE_TEMPLATE/` (none existed — verified) → Task 2. ✅
+- Immutability redefined as "immutable once merged to `master`", located by grep → Task 4, four sites, grep included as Step 1. ✅
+- New `patterns/` guide persisted and linked → Task 5. ✅
+- Final task is a trivial watched canary with a falsifiable criterion per step, both `ci.yml` and `claude-code-review.yml` confirmed running, tampering confirmed failing, plus the first-execution and branch-validation warnings → Task 6. ✅
+
+**Placeholder scan:** No TBD/TODO. `<N>` is the canary issue number and is unknown only until Task 6
+Step 1 creates it; every other identifier is concrete. The bot login in `allowed_bots` is written as
+`claude` on the evidence that the existing `dependabot` entry omits its `[bot]` suffix, and Task 6
+Step 4 criterion 3 is the explicit falsification with the correction procedure stated. No ADR number
+is allocated, deliberately — F0 ships concurrently and the reason is recorded in Task 5.
+
+**Type/name consistency:** The labels `agent:plan` / `agent:go` are byte-identical across Task 1's
+`gh label create`, both jobs' `if:` expressions, both `label_trigger:` inputs, the issue-form
+guidance, the pattern guide, and every canary command. The branch convention `agent/issue-<N>` is
+identical in the `plan` job's `prep` step, the `go` job's `checkout.ref` and `approved` step, the
+pattern's troubleshooting table, and Task 6. `${{ steps.prep.outputs.branch }}`,
+`${{ steps.approved.outputs.sha }}` and `${{ steps.approved.outputs.plan_path }}` are each written
+by exactly one `$GITHUB_OUTPUT` line and read only under those names. The plan-path predicate
+(`docs/superpowers/plans/*.md`, exactly one file vs `origin/master`) is stated identically in the
+phase-1 guard and the phase-2 pre-flight. `CLAUDE_CODE_OAUTH_TOKEN` is the only Claude credential
+anywhere in this plan; `ANTHROPIC_API_KEY` appears nowhere.


### PR DESCRIPTION
Task-by-task implementation plans for the two software-factory sub-projects that run first, planned against the [decomposition spec](../blob/master/docs/superpowers/specs/2026-08-01-software-factory-decomposition-design.md) merged in #72.

- `2026-08-01-factory-f0-harden-the-gate.md` — 9 tasks (issue #73)
- `2026-08-01-factory-f2-issue-intake.md` — 6 tasks (issue #75)

Both follow the plan house style: verbatim-embedded content rather than descriptions, `Run:`/`Expected:` verification on every step, a commit step per task, and a closing `**Files:** none` task that proves the change in production — because a green Actions run is not proof of success.

### Findings from writing the plans that the spec did not have

- **`GITHUB_TOKEN` has no `administration` scope** — the `permissions:` block offers no such key — so the ruleset drift check cannot read rulesets with it. F0 provisions a fine-grained PAT scoped to Administration: read, includes a step proving it *cannot* write, and fails loudly when the secret is absent rather than skipping green.
- **Ruleset `8769144` also carries `"exclude": ["refs/heads/dependabot/*"]`**, which the spec did not record. R1 preserves it verbatim rather than silently dropping it.
- **The check-run name was confirmed live** as `Build & verify` (app_id 15368) rather than assumed, since it is about to be pinned in a ruleset.
- **F2 depends on F0 for more than `FACTORY_ENABLED`:** pre-F0, the `~ALL` PR-required rule rejects `agent:go`'s second push to an existing branch. Recorded in the roadmap row.

### Design strengthened beyond the spec

F2's re-plan guard now has the **non-agent** step derive and post the authoritative plan path and SHA from `git rev-parse`, so the agent never handles the value it is judged against. An honest limitation is recorded alongside it: because the PR opens inside the agent step, the guard necessarily runs after it, so a tampered run leaves an open PR and fails on the *issue* rather than the PR.

F0 creates R2 **before** updating R1 so `master` is never momentarily without an approval requirement, updates `8769144` in place via `PUT` so the phone rollback needs no id lookup, and proves the rollback at a desk before anything depends on it.

Docs only — no code, no workflow changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)