### PR TITLE
F0: harden the gate (fork-PR fix, ruleset split, kill switch, alerting)

### DIFF
--- a/.github/rulesets/R1-all-branches.json
+++ b/.github/rulesets/R1-all-branches.json
@@ -1,0 +1,30 @@
+{
+  "name": "R1 — all branches: no deletion, no force-push",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "exempt"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+        "refs/heads/dependabot/*"
+      ],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/.github/rulesets/R2-default-branch.json
+++ b/.github/rulesets/R2-default-branch.json
@@ -38,7 +38,8 @@
       "parameters": {
         "required_status_checks": [
           {
-            "context": "Build & verify"
+            "context": "Build & verify",
+            "integration_id": 15368
           }
         ],
         "strict_required_status_checks_policy": false

--- a/.github/rulesets/R2-default-branch.json
+++ b/.github/rulesets/R2-default-branch.json
@@ -1,0 +1,48 @@
+{
+  "name": "R2 — default branch: PR approval + green build",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "exempt"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "Build & verify"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,15 @@ jobs:
 
       # Publish JUnit results as a check run with inline annotations, even when
       # the build failed, so failing tests are visible on the PR.
+      #
+      # continue-on-error: for a `pull_request` from a FORK, GITHUB_TOKEN is read-only
+      # regardless of this workflow's `permissions:` block (the key can only reduce), so the
+      # checks-API write 403s. Reporting is signal, never the gate — `Build & verify` is a
+      # required status check (see .github/rulesets/R2-default-branch.json) and must not go
+      # red because a reporter could not write. The `./gradlew build` step above is the gate.
       - name: Publish test results
         if: always()
+        continue-on-error: true
         uses: mikepenz/action-junit-report@v5
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -50,11 +57,11 @@ jobs:
           annotate_only: true
           require_tests: true
 
-      # Comment a JaCoCo coverage summary on the PR. The glob picks up every module's report.
-      # Threshold is 0 here (the build already owns the soft coverage gate); this step is
-      # signal, not a blocker.
+      # Skipped on fork PRs: the read-only fork GITHUB_TOKEN cannot post a PR comment, so this
+      # can only 403. continue-on-error covers the residual case (e.g. a comment-locked PR).
       - name: Publish coverage summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ "master" ]
 
+# Queue, never cancel. `Build & verify` is a REQUIRED status check on master
+# (.github/rulesets/R2-default-branch.json), and a *cancelled* check run does not satisfy a
+# required check — it is neither success nor a pending state the merge box waits on. Cancelling
+# a superseded run would leave the PR blocked behind a grey check with no visible cause.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
 # Least-privilege default for the whole workflow. Individual jobs elevate only
 # the scopes their actions need (see each job's `permissions:` block).
 permissions:
@@ -57,6 +65,10 @@ jobs:
           annotate_only: true
           require_tests: true
 
+      # Comment a JaCoCo coverage summary on the PR. The glob picks up every module's report.
+      # Threshold is 0 here (the build already owns the soft coverage gate); this step is
+      # signal, not a blocker.
+      #
       # Skipped on fork PRs: the read-only fork GITHUB_TOKEN cannot post a PR comment, so this
       # can only 403. continue-on-error covers the residual case (e.g. a comment-locked PR).
       - name: Publish coverage summary

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,9 @@ concurrency:
 jobs:
   claude-review:
     # Skip drafts — they aren't ready for review and would waste subscription usage.
-    if: ${{ !github.event.pull_request.draft }}
+    # vars.FACTORY_ENABLED is the kill switch; absent/mistyped means OFF (fail-safe).
+    # This job produces no required check, so a skipped run blocks no merge.
+    if: ${{ !github.event.pull_request.draft && vars.FACTORY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
     # Without this the default is 360 minutes of flat-rate seat on a wedged review.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,11 +4,20 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# Opposite of ci.yml on purpose: a review of an older commit is waste, not signal, and this
+# workflow produces no required check, so cancelling it blocks nothing.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip drafts — they aren't ready for review and would waste subscription usage.
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # Without this the default is 360 minutes of flat-rate seat on a wedged review.
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write   # REQUIRED to post reviews/comments (was `read` — the no-op cause)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,8 +14,12 @@ jobs:
   claude-review:
     # Skip drafts — they aren't ready for review and would waste subscription usage.
     # vars.FACTORY_ENABLED is the kill switch; absent/mistyped means OFF (fail-safe).
+    # Skip fork PRs — secrets (including CLAUDE_CODE_OAUTH_TOKEN) are unavailable to a
+    # pull_request run from a fork, so the action step would fail and the failure() alert below
+    # would then 403 on gh pr comment with a read-only GITHUB_TOKEN: a red job whose own alert is
+    # swallowed, and nobody notified. A visibly skipped job is the honest outcome here.
     # This job produces no required check, so a skipped run blocks no merge.
-    if: ${{ !github.event.pull_request.draft && vars.FACTORY_ENABLED == 'true' }}
+    if: ${{ !github.event.pull_request.draft && vars.FACTORY_ENABLED == 'true' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
     # Without this the default is 360 minutes of flat-rate seat on a wedged review.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,3 +55,15 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           allowed_bots: 'dependabot'
+
+      # An unattended failure nobody sees is the same as no gate at all. `gh pr comment` uses
+      # this job's `pull-requests: write`; the @-mention is what makes GitHub Mobile push a
+      # notification (schedule-failure email does not cover pull_request-triggered runs).
+      # failure() deliberately excludes cancelled() — a cancellation is a human act.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --body \
+            "@Muddl \`Claude Code Review\` failed on this PR. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,16 @@ on:
 
 jobs:
   claude:
+    # Kill switch. vars.* is always a string, so an unset, deleted, or mistyped variable
+    # evaluates false — absent means OFF, which is the fail-safe direction. Flip it at
+    # /settings/variables/actions from any browser, phone included.
+    # See docs/knowledge/patterns/factory-kill-switch.md for the full escalation ladder.
     if: |
+      vars.FACTORY_ENABLED == 'true' && (
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
     timeout-minutes: 30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write   # post review comments when @claude-mentioned on a PR

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,3 +55,15 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
+      # Comments back on whichever issue or PR triggered the run. `gh issue comment` works on a
+      # PR number too (PRs are issues); this job already holds issues: write and
+      # pull-requests: write. The @-mention is the phone-notification channel.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh issue comment "$TARGET" --body \
+            "@Muddl \`Claude Code\` failed here. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: write        # create the housekeeping branch
       pull-requests: write   # open the PR
+      issues: write          # post the @Muddl failure alert (see the last step)
       id-token: write
     steps:
       - name: Checkout (full history for the commit gate)
@@ -129,3 +130,20 @@ jobs:
             --title "chore: weekly housekeeping ($STAMP)" \
             --body "Automated housekeeping pass (docs / KB / roadmap / skills / agents). Review the diff before merging." \
             --base master --head "$BRANCH"
+
+      # This is the only unattended cron in the factory: it fires at 09:00 UTC Monday with
+      # nobody watching. There is no issue or PR context here, so the alert goes to the
+      # long-lived tracking issue in vars.FACTORY_ALERT_ISSUE. If that variable is unset the
+      # step fails loudly rather than swallowing the alert — a silent alerter is worse than none.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERT_ISSUE: ${{ vars.FACTORY_ALERT_ISSUE }}
+        run: |
+          if [ -z "$ALERT_ISSUE" ]; then
+            echo "::error title=Alerting::FACTORY_ALERT_ISSUE is unset; the failure alert had nowhere to go."
+            exit 1
+          fi
+          gh issue comment "$ALERT_ISSUE" --body \
+            "@Muddl \`Weekly Housekeeping\` failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -117,10 +117,19 @@ jobs:
           # using an extraheader, and this step — which exists to route around a credential footgun
           # — should hold the same bar. The URL must be credential-free or its dead inline token
           # would still be preferred over the header.
-          # GITHUB_SERVER_URL rather than a literal github.com, and the extraheader config key is
-          # derived from the same value so host and key cannot drift apart.
+          #
+          # The host comes from GITHUB_SERVER_URL rather than a literal github.com, and the
+          # extraheader config key below is derived from that same value, so the host and the
+          # config key cannot drift apart.
           git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+
+          # GitHub's automatic log redaction matches the LITERAL registered secret, not transforms
+          # of it, so the base64 of "x-access-token:$GH_TOKEN" is NOT masked by default. Register
+          # it explicitly: nothing here prints it today, but ACTIONS_STEP_DEBUG tracing would show
+          # it in the clear. Defence in depth on a step whose credential handling has already
+          # broken twice. (#71)
           AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$AUTH_HEADER"
 
           git checkout -b "$BRANCH"
           git add -A

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   housekeeping:
     runs-on: ubuntu-latest
+    # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
+    # This job runs unattended on a Monday cron — an unbounded hang is the worst case.
+    timeout-minutes: 30
     permissions:
       contents: write        # create the housekeeping branch
       pull-requests: write   # open the PR

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -124,11 +124,14 @@ jobs:
           git remote set-url origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
 
           # GitHub's automatic log redaction matches the LITERAL registered secret, not transforms
-          # of it, so the base64 of "x-access-token:$GH_TOKEN" is NOT masked by default. Register
-          # it explicitly: nothing here prints it today, but ACTIONS_STEP_DEBUG tracing would show
-          # it in the clear. Defence in depth on a step whose credential handling has already
-          # broken twice. (#71)
-          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          # of it, so the base64 of "x-access-token:$GH_TOKEN" is NOT masked by default. Mask the
+          # blob itself — a line containing only the base64, with no "AUTHORIZATION: basic "
+          # prefix, would not be caught by a mask registered on the full header string. Nothing
+          # here prints either today, but ACTIONS_STEP_DEBUG tracing would show them in the clear.
+          # Defence in depth on a step whose credential handling has already broken twice. (#71)
+          AUTH_B64="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$AUTH_B64"
+          AUTH_HEADER="AUTHORIZATION: basic $AUTH_B64"
           echo "::add-mask::$AUTH_HEADER"
 
           git checkout -b "$BRANCH"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -18,6 +18,10 @@ permissions:
 
 jobs:
   housekeeping:
+    # Kill switch. This is the only unattended cron in the factory, so it is the job the switch
+    # exists for. Absent/mistyped variable means OFF. Gating the job (not the step) also skips
+    # the git/PR steps, so a disabled factory opens no branches.
+    if: vars.FACTORY_ENABLED == 'true'
     runs-on: ubuntu-latest
     # claude-code-action exposes no timeout of its own; its message loop runs until the job's.
     # This job runs unattended on a Monday cron — an unbounded hang is the worst case.

--- a/.github/workflows/ruleset-drift.yml
+++ b/.github/workflows/ruleset-drift.yml
@@ -1,0 +1,54 @@
+name: Ruleset Drift
+
+on:
+  schedule:
+    - cron: '17 7 * * *'   # daily 07:17 UTC — offset off the hour to dodge cron congestion
+  workflow_dispatch:
+
+# READ ONLY, deliberately. GITHUB_TOKEN has no `administration` scope at all — the permissions
+# key does not offer one — so ruleset reads use a dedicated fine-grained PAT whose ONLY grant is
+# Administration: read. No credential in this repository's Actions can write a ruleset; that is
+# the point (see ADR-0019).
+permissions:
+  contents: read
+
+# NOT gated on vars.FACTORY_ENABLED. This is the safety net that tells you the gate is still
+# there; it must keep running precisely when the factory has been switched off.
+concurrency:
+  group: ruleset-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Ruleset drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write    # post the @Muddl alert on drift
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compare live rulesets against committed JSON
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_READ_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error title=Ruleset drift::RULESET_READ_TOKEN is not set. Refusing to skip green — an unverifiable gate is indistinguishable from an absent one. Create a fine-grained PAT scoped to this repo with Administration: read (and nothing else) and add it as the RULESET_READ_TOKEN secret."
+            exit 1
+          fi
+          bash scripts/rulesets/check-drift.sh
+
+      - name: Alert on drift
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERT_ISSUE: ${{ vars.FACTORY_ALERT_ISSUE }}
+        run: |
+          if [ -z "$ALERT_ISSUE" ]; then
+            echo "::error title=Alerting::FACTORY_ALERT_ISSUE is unset; the drift alert had nowhere to go."
+            exit 1
+          fi
+          gh issue comment "$ALERT_ISSUE" --body \
+            "@Muddl **Branch protection has drifted** from \`.github/rulesets/\`. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ruleset-drift.yml
+++ b/.github/workflows/ruleset-drift.yml
@@ -31,24 +31,35 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compare live rulesets against committed JSON
+        id: compare
         env:
           GH_TOKEN: ${{ secrets.RULESET_READ_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
+            echo "reason=missing-token" >> "$GITHUB_OUTPUT"
             echo "::error title=Ruleset drift::RULESET_READ_TOKEN is not set. Refusing to skip green — an unverifiable gate is indistinguishable from an absent one. Create a fine-grained PAT scoped to this repo with Administration: read (and nothing else) and add it as the RULESET_READ_TOKEN secret."
             exit 1
           fi
           bash scripts/rulesets/check-drift.sh
 
+      # Branches on the real cause: a missing RULESET_READ_TOKEN is a config gap, not drift, and
+      # the first alert this system ever sends would otherwise misreport the former as the latter.
+      # Both cases must still alert — never trade a wrong message for silence.
       - name: Alert on drift
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALERT_ISSUE: ${{ vars.FACTORY_ALERT_ISSUE }}
+          REASON: ${{ steps.compare.outputs.reason }}
         run: |
           if [ -z "$ALERT_ISSUE" ]; then
             echo "::error title=Alerting::FACTORY_ALERT_ISSUE is unset; the drift alert had nowhere to go."
             exit 1
           fi
-          gh issue comment "$ALERT_ISSUE" --body \
-            "@Muddl **Branch protection has drifted** from \`.github/rulesets/\`. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "$REASON" = "missing-token" ]; then
+            BODY="@Muddl \`ruleset-drift.yml\` could not run: RULESET_READ_TOKEN secret is not set (this is a missing credential, not confirmed drift). Run: $RUN_URL"
+          else
+            BODY="@Muddl **Branch protection has drifted** from \`.github/rulesets/\`. Run: $RUN_URL"
+          fi
+          gh issue comment "$ALERT_ISSUE" --body "$BODY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ The full test suite runs **offline with no Riot API key**. Do not introduce test
 keys or network access; use WireMock (adapters) or port fakes (services) instead.
 
 The above is the offline CI gate and needs no keys. A separate **live eval harness** (`eval/`,
-Python + mcp-eval) runs agent-driven tests against the real Riot API post-merge over both transports
+Python + mcp-eval) runs agent-driven tests against the real Riot API over both transports,
+**dispatched manually** (`live-eval.yml` is `workflow_dispatch:` only — it does **not** run on merge)
 — see [`docs/knowledge/patterns/live-eval-harness.md`](docs/knowledge/patterns/live-eval-harness.md)
 and [ADR-0012](docs/knowledge/decisions/ADR-0012-live-eval-harness.md). It never gates a merge and
 needs `ANTHROPIC_API_KEY` (a separate credential bucket from `CLAUDE_CODE_OAUTH_TOKEN`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ in CI.
 ## Live evals (optional, key-gated)
 
 The offline suite above is the gate and needs no keys. A separate live suite in [`eval/`](eval/README.md)
-drives the server against the real Riot API with [mcp-eval](https://mcp-eval.ai/). It runs post-merge
-on CI and never blocks a merge. To run it locally you need `uv`, a personal `RIOT_API_KEY`, and an
+drives the server against the real Riot API with [mcp-eval](https://mcp-eval.ai/). It is dispatched
+on demand on CI (`workflow_dispatch`, not on merge) and never blocks a merge. To run it locally you
+need `uv`, a personal `RIOT_API_KEY`, and an
 `ANTHROPIC_API_KEY` (separate from any Claude Code OAuth token):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Architecture, coverage, and formatting are checked in the same run.
 ./gradlew spotlessApply  # auto-format sources (run before committing)
 ```
 
-Beyond the offline CI gate, a post-merge [live eval harness](eval/README.md) drives the server
-against the real Riot API over stdio and sse using [mcp-eval](https://mcp-eval.ai/), verifying the
-transports handshake, endpoint paths resolve, and Riot's error behaviours have not drifted. It runs
-post-merge only and never blocks a merge.
+Beyond the offline CI gate, a [live eval harness](eval/README.md) drives the server against the
+real Riot API over stdio and sse using [mcp-eval](https://mcp-eval.ai/), verifying the transports
+handshake, endpoint paths resolve, and Riot's error behaviours have not drifted. It is **dispatched
+on demand** (Actions tab or `gh workflow run live-eval.yml`) and never blocks a merge.
 
 ## Documentation
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -45,6 +45,7 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [Add an MCP tool](patterns/add-an-mcp-tool.md)
 - [Add an adapter test](patterns/add-an-adapter-test.md)
 - [Run and extend the live eval harness](patterns/live-eval-harness.md)
+- [Stopping the factory (escalation ladder)](patterns/factory-kill-switch.md)
 
 ## Hydrate / Persist protocol
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -38,6 +38,7 @@ This README is the **single source of truth** for the hydrate/persist protocol.
 - [ADR-0016 — Bounded list results for MCP tools](decisions/ADR-0016-bounded-list-results.md)
 - [ADR-0017 — Transport-scoped live eval coverage](decisions/ADR-0017-transport-scoped-live-eval.md)
 - [ADR-0018 — Automated PRs are authored by a non-Actions identity so the review gate applies](decisions/ADR-0018-housekeeping-pr-review-gate.md)
+- [ADR-0019 — Gate hardening: ruleset topology, local-only application, and factory bounds](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md)
 
 ### Patterns
 

--- a/docs/knowledge/decisions/ADR-0012-live-eval-harness.md
+++ b/docs/knowledge/decisions/ADR-0012-live-eval-harness.md
@@ -1,7 +1,20 @@
 # ADR-0012: Live agent-driven eval harness (mcp-eval)
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-08-01)
 - **Date:** 2026-07-17
+
+> **Amendment (2026-08-01):** the Decision's opening line — "run post-merge on CI" — and the
+> Consequences' "automated post-merge" were never true of the shipped workflow, and contradict this
+> ADR's own "On-demand, non-blocking" bullet below, which is the accurate one.
+> `.github/workflows/live-eval.yml` is `workflow_dispatch:` only; the `push` trigger was removed and
+> never replaced. **Merges get no live coverage unless someone dispatches the workflow by hand** —
+> which matters because `gotchas.md` records three bug classes only the live eval has ever caught,
+> every one of which passed the offline suite. Scheduling it was considered and rejected in the
+> [software-factory decomposition spec](../../superpowers/specs/2026-08-01-software-factory-decomposition-design.md):
+> the preflight *skips green* on a 401/403 and Riot dev keys expire every 24 hours, so a weekly cron
+> would yield one real run followed by green no-ops — reintroducing "silent failure that looks like
+> success" as the mitigation for it. The coverage gap during unattended weeks is recorded honestly
+> instead. Swept from all prose by F0 ([ADR-0019](ADR-0019-gate-hardening-and-ruleset-topology.md)).
 
 ## Context
 

--- a/docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md
+++ b/docs/knowledge/decisions/ADR-0017-transport-scoped-live-eval.md
@@ -1,7 +1,14 @@
 # ADR-0017: Transport-scoped live eval coverage
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-08-01)
 - **Date:** 2026-07-23
+
+> **Amendment (2026-08-01):** "Relationship to ADR-0012" below describes the harness's purpose as
+> "agent-driven, live-Riot, post-merge, non-gating". Read **dispatch-only** for "post-merge":
+> `live-eval.yml` is `workflow_dispatch:` only and has never run on merge. Nothing else in this ADR
+> changes — the coverage narrowing it decides is independent of the trigger. See
+> [ADR-0012](ADR-0012-live-eval-harness.md)'s amendment and
+> [ADR-0019](ADR-0019-gate-hardening-and-ruleset-topology.md).
 
 ## Context
 

--- a/docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md
+++ b/docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md
@@ -1,0 +1,77 @@
+# ADR-0019 — Gate hardening: ruleset topology, local-only application, and factory bounds
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+Repository ruleset `8769144` ("one ruleset to rule them all") had been active since 2025-10-09
+carrying `deletion`, `non_fast_forward`, and `pull_request{required_approving_review_count: 1}` —
+with **no required status checks at all** and with
+`{"actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "exempt"}`. `exempt` is stronger than
+`always`: rules are not evaluated for that actor and no bypass audit entry is written. So the one
+human was invisibly exempt from the only rule that existed, nothing required `Build & verify` to be
+green before merge, and the merge button was live on a red PR. Its `ref_name.include` was `~ALL`
+rather than the default branch, so a hypothetical agent branch was governed by the same
+PR-required rule as `master` — unreached only because the maintainer is exempt and `housekeeping.yml`
+performs a single branch *creation*.
+
+Separately, `ci.yml` could not pass on a fork PR at all: `GITHUB_TOKEN` is read-only for
+`pull_request` from a fork regardless of `permissions:`, and both reporting steps wrote through it
+with no `continue-on-error`. And no agent job had a timeout, a kill switch, or a failure alert.
+
+## Decision
+
+- **Fork PRs are fixed before any check becomes required.** Making `Build & verify` required while it
+  failed on every outside contribution would permanently block contributions to a public portfolio
+  repo. Reporting steps are non-fatal; the build step never is.
+- **Two rulesets, identical bypass.** R1 (`~ALL`) keeps `deletion` + `non_fast_forward` —
+  `non_fast_forward` stays repo-wide because F4 pushes revision rounds to live PR branches, where a
+  force-push erases round evidence and outdates every inline comment. R2 (`~DEFAULT_BRANCH`) carries
+  `pull_request{1 approval}` + `required_status_checks["Build & verify"]`. `8769144` is **updated in
+  place (PUT)** into R1 so its id — and therefore the rollback command — stays stable; R2 is created
+  first so `master` is never momentarily without an approval requirement.
+- **Bypass stays identical on both.** GitHub documents that rules across rulesets are aggregated with
+  "the most restrictive version of the rule applies" but documents **nothing** about how bypass is
+  evaluated when several rulesets match a ref, and `enforcement: "evaluate"` (dry-run) is
+  GitHub-Enterprise-only. An undocumented behaviour, no dry-run, and a sole maintainer who cannot
+  approve his own PRs is the combination not to experiment on. The tighter `bypass_actors: []`
+  variant is deferred, gated on testing layered bypass on a **throwaway probe repo**.
+- **Rulesets are applied locally and verified by CI, never applied by CI.** A workflow able to
+  rewrite rulesets could delete the approval requirement, which is strictly stronger than approving
+  its own work. Writes use the maintainer's own credential (`administration: write`) from
+  `scripts/rulesets/apply-rulesets.sh`, which refuses to run under `GITHUB_ACTIONS`. `ruleset-drift.yml`
+  reads with a fine-grained PAT scoped to **Administration: read** and nothing else, and fails loudly
+  when that secret is absent rather than skipping green.
+- **Bounds and control.** `timeout-minutes` on every job running `claude-code-action` (the action
+  exposes no timeout of its own). `cancel-in-progress: false` on `ci.yml` — a cancelled check run
+  never satisfies a required check — and `true` on `claude-code-review.yml`. Every agent job gates on
+  `vars.FACTORY_ENABLED == 'true'`; `ci.yml` and `ruleset-drift.yml` deliberately do not. Failures
+  post an `@Muddl` mention, the only channel GitHub Mobile pushes for `issues`- and
+  `pull_request`-triggered runs.
+
+## Consequences
+
+- **Machine identities cannot merge red.** That is the property this buys, and it is bounded: the
+  maintainer remains `exempt` and can still merge red. This residual risk is **stated, not solved**;
+  closing it for the human is a post-trip item.
+- Branch protection now has a committed, diffable definition, and a hand-edit in the GitHub UI turns a
+  daily workflow red within 24 hours instead of going unnoticed indefinitely.
+- Three phone-reachable rungs exist for stopping the factory
+  ([pattern guide](../patterns/factory-kill-switch.md)), and a ruleset lock-out is undone by one
+  copy-pasteable `gh api --method PUT ... -f enforcement=disabled`.
+- Every workflow file touched here contains `claude-code-action` or is adjacent to it, so the PR that
+  ships this receives **no Claude review** — the action refuses to run when the workflow file differs
+  from the default-branch copy and records that as an annotation on a *successful* job.
+- The live-eval "post-merge" claim is corrected everywhere outside immutable history; ADR-0012 and
+  ADR-0017 are amended rather than edited, per the knowledge-base reversal rule.
+- **The applier and comparator are hardened beyond this plan's original script text**, on a review
+  finding and an explicit maintainer ruling. Both scripts now fail loudly on an ambiguous
+  ruleset-name lookup rather than silently taking the first match; `check-drift.sh` additionally
+  asserts that R1 and R2 are the *only* live rulesets, closing the route by which a hand-added
+  third ruleset carrying an `exempt` bypass would weaken the property F0 buys while the check
+  stayed green; and `apply-rulesets.sh` rejects unrecognised arguments rather than treating a
+  mistyped `--dry-run` as a live apply. A known limitation is recorded in the
+  [kill-switch pattern guide](../patterns/factory-kill-switch.md): GitHub disables `schedule`
+  triggers after 60 days of repository inactivity, so the drift check decays silently in exactly
+  the quiet period it exists to cover.

--- a/docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md
+++ b/docs/knowledge/decisions/ADR-0019-gate-hardening-and-ruleset-topology.md
@@ -52,11 +52,20 @@ with no `continue-on-error`. And no agent job had a timeout, a kill switch, or a
 
 ## Consequences
 
-- **Machine identities cannot merge red.** That is the property this buys, and it is bounded: the
-  maintainer remains `exempt` and can still merge red. This residual risk is **stated, not solved**;
-  closing it for the human is a post-trip item.
-- Branch protection now has a committed, diffable definition, and a hand-edit in the GitHub UI turns a
-  daily workflow red within 24 hours instead of going unnoticed indefinitely.
+- **Machine identities cannot merge red — except ones that inherit the admin role.** The bypass on
+  both rulesets is `{"actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "exempt"}` — the
+  admin *role*, not a named human. Any credential that authenticates as that role inherits the same
+  exemption, including a fine-grained PAT minted under the admin account: `HOUSEKEEPING_TOKEN`
+  already holds `Pull requests: read/write`, which covers `PUT /pulls/{n}/merge`, so a machine
+  identity **can** merge red today. The property this buys therefore holds only for identities that
+  are **not** the admin role. **F1 (machine identity via GitHub App) is what actually closes this**:
+  an App installation authenticates as `actor_type: Integration`, not `RepositoryRole` 5, so it does
+  not inherit the bypass a PAT does. This residual risk is **stated, not solved** here; closing it —
+  for the human and for any admin-scoped credential alike — is future work, F1 chief among it.
+- Branch protection now has a committed, diffable definition, and the drift check exists to make a
+  hand-edit in the GitHub UI go red within a day instead of unnoticed indefinitely — **once the
+  rulesets are applied and `RULESET_READ_TOKEN` is in place**. Neither is true yet: this session made
+  no production mutations, so today a hand-edit in the UI still goes unnoticed exactly as before.
 - Three phone-reachable rungs exist for stopping the factory
   ([pattern guide](../patterns/factory-kill-switch.md)), and a ruleset lock-out is undone by one
   copy-pasteable `gh api --method PUT ... -f enforcement=disabled`.

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -154,7 +154,8 @@ record it (Plan C deferred this to Plan D's arch audit). The honest exception li
 
 `eval/` is a `uv`-managed Python (`mcpevals`) project — never built by Gradle, never part of the
 offline `./gradlew build` gate. It drives the built server jar against the **live** Riot API on CI,
-on manual dispatch only (`.github/workflows/live-eval.yml` is `workflow_dispatch:`), and never blocks a merge. Consequences to know:
+on manual dispatch only (`.github/workflows/live-eval.yml` is `workflow_dispatch:`), and never
+blocks a merge. Consequences to know:
 
 - **Needs `ANTHROPIC_API_KEY`** (agent + LLM judge). This is a *separate credential bucket* from
   `CLAUDE_CODE_OAUTH_TOKEN` (which `claude.yml` uses); the live-eval workflow must never read the
@@ -400,9 +401,12 @@ ruleset?*
 Committing ruleset JSON under `.github/rulesets/` configures nothing — GitHub reads no such path.
 Without something that applies it and something that verifies it, the JSON is documentation cosplaying
 as configuration, which is ADR-0018's exact failure shape: artifact present, property absent. This
-repo applies it with `scripts/rulesets/apply-rulesets.sh` (local only — a workflow able to rewrite
-rulesets could delete the approval requirement) and verifies it daily with `ruleset-drift.yml`, which
-fails loudly rather than skipping green when its read-only credential is missing.
+repo's design closes that gap with two pieces: `scripts/rulesets/apply-rulesets.sh` (local only — a
+workflow able to rewrite rulesets could delete the approval requirement) applies the JSON, and
+`ruleset-drift.yml` is meant to verify it daily, failing loudly rather than skipping green when its
+read-only credential is missing. **Neither piece is load-bearing yet on this branch** — the rulesets
+have not been applied and `RULESET_READ_TOKEN` does not exist — which is itself a live instance of
+the lesson above: the committed JSON alone configures nothing until something applies and verifies it.
 
 There is also no safe middle setting to rehearse a ruleset change in: `enforcement: "evaluate"`, the
 dry-run mode, is **"only available with GitHub Enterprise"** and does not exist on a free personal

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -154,7 +154,7 @@ record it (Plan C deferred this to Plan D's arch audit). The honest exception li
 
 `eval/` is a `uv`-managed Python (`mcpevals`) project — never built by Gradle, never part of the
 offline `./gradlew build` gate. It drives the built server jar against the **live** Riot API on CI,
-post-merge only (`.github/workflows/live-eval.yml`), and never blocks a merge. Consequences to know:
+on manual dispatch only (`.github/workflows/live-eval.yml` is `workflow_dispatch:`), and never blocks a merge. Consequences to know:
 
 - **Needs `ANTHROPIC_API_KEY`** (agent + LLM judge). This is a *separate credential bucket* from
   `CLAUDE_CODE_OAUTH_TOKEN` (which `claude.yml` uses); the live-eval workflow must never read the
@@ -189,7 +189,7 @@ pass because our fixtures were fully populated; only live data has the nulls.
 **Rule:** declare Riot DTO number/boolean fields as boxed wrappers (`Integer`/`Long`/`Boolean`), not
 primitives. `String`s and `List`s are already null-safe. When you add a DTO, also add a WireMock case
 that feeds `null` for the nullable-looking fields and asserts it parses — that reproduces this class
-of failure offline instead of waiting for the post-merge live eval. Boxing `boolean`→`Boolean` also
+of failure offline instead of waiting for someone to dispatch the live eval. Boxing `boolean`→`Boolean` also
 renames the Lombok getter (`isX()` → `getX()`); update call sites.
 
 ## Adding a primitive field to an existing Riot-mapped DTO breaks its adapter test
@@ -369,3 +369,44 @@ credential-handover gotcha above) and became reachable the moment it was fixed.
 Left to fail loudly on purpose. The alternative — a run-id suffix — would silently open a second PR
 proposing the same week's maintenance, and two competing housekeeping PRs is a worse failure than a
 red run. If you need to re-run a week, delete the existing branch and its PR first.
+
+## `GITHUB_TOKEN` is read-only on fork PRs regardless of the `permissions:` block
+
+For a `pull_request` event from a **forked** repository, `GITHUB_TOKEN` is issued read-only. The
+workflow's `permissions:` key can only *reduce* a token's scopes, never raise them above what the
+event grants — so `checks: write` and `pull-requests: write` are silently ineffective there. Any
+step that writes (a check run, a PR comment, a label) gets `403` and, without `continue-on-error`,
+takes the whole job red. This made `Build & verify` fail on every outside contribution while nobody
+noticed, because no outside contribution had arrived.
+
+It matters far more once a job is a **required status check**: a reporter that cannot write then
+makes fork PRs permanently unmergeable. Keep reporting steps `continue-on-error: true` (or gate them
+on `github.event.pull_request.head.repo.fork == false`) so a job's conclusion reflects the build, not
+the reporter. The reverse is never acceptable — never put `continue-on-error` on the build step
+itself, which turns the required check into decoration.
+
+## A *cancelled* check run never satisfies a required status check
+
+`concurrency: cancel-in-progress: true` on a workflow that produces a required check is a trap. The
+superseded run reports `conclusion: cancelled`, which is neither a success nor a pending state the
+merge box waits on, so the PR sits blocked behind a grey check with no error anywhere to explain it.
+`ci.yml` therefore uses `cancel-in-progress: false` (queue, never cancel) while
+`claude-code-review.yml` — which produces no required check — uses `true`, where a superseded review
+is pure waste. Decide this per workflow by asking one question: *is this job's name pinned in a
+ruleset?*
+
+## `.github/rulesets/` is not a GitHub path, and `enforcement: "evaluate"` is Enterprise-only
+
+Committing ruleset JSON under `.github/rulesets/` configures nothing — GitHub reads no such path.
+Without something that applies it and something that verifies it, the JSON is documentation cosplaying
+as configuration, which is ADR-0018's exact failure shape: artifact present, property absent. This
+repo applies it with `scripts/rulesets/apply-rulesets.sh` (local only — a workflow able to rewrite
+rulesets could delete the approval requirement) and verifies it daily with `ruleset-drift.yml`, which
+fails loudly rather than skipping green when its read-only credential is missing.
+
+There is also no safe middle setting to rehearse a ruleset change in: `enforcement: "evaluate"`, the
+dry-run mode, is **"only available with GitHub Enterprise"** and does not exist on a free personal
+repo. Rulesets are `active` or `disabled`. Rehearse risky bypass topologies on a throwaway probe
+repo, never on this one — and note that GitHub documents rule *aggregation* across rulesets ("the most
+restrictive version of the rule applies") while documenting **nothing** about how *bypass* is
+evaluated when several rulesets match a ref. That silence is why R1 and R2 carry identical bypass.

--- a/docs/knowledge/patterns/factory-kill-switch.md
+++ b/docs/knowledge/patterns/factory-kill-switch.md
@@ -65,6 +65,25 @@ repository — there is no "try it safely" middle setting. Disabled or active.
 Re-enable by re-running `scripts/rulesets/apply-rulesets.sh` from a desk, which restores the
 committed JSON exactly and is then confirmed by `ruleset-drift.yml`.
 
+## Known limitation: `ruleset-drift.yml`'s schedule goes silent after 60 days of inactivity
+
+GitHub disables `on.schedule` triggers on a repository with no activity for 60 days, and does so
+without failing anything — the workflow simply stops being invoked, with no error, no red run, no
+notification. "Factory switched off" (Rung 1 or 2 above) is strongly correlated with "repo goes
+quiet", which is exactly the condition that trips this. The result is a green-by-absence safety
+net: no runs, no red, no signal that branch protection has drifted.
+
+This is a platform behavior, not a bug in `ruleset-drift.yml` or `check-drift.sh` — there is no
+code fix for it in this repository. Mitigation is manual: after any extended quiet period (or
+before relying on the schedule again), confirm it still fires —
+`https://github.com/Muddl/riot-api-mcp-server/actions/workflows/ruleset-drift.yml` → **Run
+workflow** (`workflow_dispatch`) — and re-enable it from `···` → **Enable workflow** if GitHub has
+disabled it. Any commit to the repository also counts as activity and resets the 60-day clock.
+
+A cross-job freshness assertion (e.g. a separate check that alerts if `ruleset-drift.yml` has not
+run in N days) would close this gap in software rather than relying on a human to remember, but
+that is out of scope for this task and is tracked as a follow-up.
+
 ## After using any rung
 
 Say so on the alert thread (`vars.FACTORY_ALERT_ISSUE`) — an unexplained silent factory is

--- a/docs/knowledge/patterns/factory-kill-switch.md
+++ b/docs/knowledge/patterns/factory-kill-switch.md
@@ -1,0 +1,72 @@
+# Stopping the factory (escalation ladder)
+
+Every rung is reachable from a **mobile browser** with no laptop, no local checkout, and no
+`gh` install. Rungs are ordered least-destructive first; each is strictly stronger than the one
+above it. Use the lowest rung that solves the problem.
+
+## Rung 1 — flip `FACTORY_ENABLED` (seconds, reversible, no side effects)
+
+`https://github.com/Muddl/riot-api-mcp-server/settings/variables/actions` → `FACTORY_ENABLED` →
+Update → set to anything other than `true` (use `false`).
+
+Every agent job is gated on `vars.FACTORY_ENABLED == 'true'`, so this stops
+`claude.yml`, `claude-code-review.yml`, and `housekeeping.yml` at the job level: they report
+`skipped`, spend nothing, and create no branches.
+
+**What keeps running on purpose:** `ci.yml` (it produces the required `Build & verify` check —
+gating it would make every PR unmergeable), `ruleset-drift.yml` (a safety net must survive the
+kill switch), and `live-eval.yml` (manual dispatch only, metered bucket).
+
+Runs already **in flight** are not affected — the gate is evaluated at job start. Cancel them
+from the Actions tab if that matters.
+
+## Rung 2 — disable the workflow from the Actions tab (survives a variable being re-set)
+
+`https://github.com/Muddl/riot-api-mcp-server/actions` → pick the workflow → `···` →
+**Disable workflow**.
+
+Stronger than rung 1 because it is not a value another automation could set back, and because it
+prevents the run from being *created* rather than skipping it after creation.
+
+## Rung 3 — revoke `CLAUDE_CODE_OAUTH_TOKEN` (fails every agent run closed)
+
+`https://github.com/Muddl/riot-api-mcp-server/settings/secrets/actions` → delete
+`CLAUDE_CODE_OAUTH_TOKEN`, then revoke it at the Claude Code account level.
+
+Every `claude-code-action` step then fails authentication. This is the rung to use when the
+concern is "the agent is doing something harmful", not "the agent is wasting money": it is the
+only rung that cannot be undone by anything that already has repo write.
+
+Does **not** touch `ANTHROPIC_API_KEY`, which belongs to `live-eval.yml` alone (ADR-0012).
+
+## Ruleset rollback (separate axis — protection, not agents)
+
+If a ruleset change locks the repository — e.g. a required check that never reports, so nothing
+can merge — disable the ruleset rather than editing it. Copy-pasteable, and it works from the
+`gh` CLI on a phone or from any shell:
+
+```bash
+# R1 (~ALL: deletion, non_fast_forward) — id is stable and known
+gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled
+
+# R2 (~DEFAULT_BRANCH: PR approval + Build & verify) — id resolved by name
+gh api --method PUT \
+  "repos/Muddl/riot-api-mcp-server/rulesets/$(gh api repos/Muddl/riot-api-mcp-server/rulesets \
+    --jq '.[] | select(.name | startswith("R2")) | .id')" \
+  -f enforcement=disabled
+```
+
+Browser equivalent: `https://github.com/Muddl/riot-api-mcp-server/settings/rules` → the ruleset →
+Enforcement status → **Disabled** → Save.
+
+`enforcement: "evaluate"` (dry-run) is **GitHub Enterprise only** and is not available on this
+repository — there is no "try it safely" middle setting. Disabled or active.
+
+Re-enable by re-running `scripts/rulesets/apply-rulesets.sh` from a desk, which restores the
+committed JSON exactly and is then confirmed by `ruleset-drift.yml`.
+
+## After using any rung
+
+Say so on the alert thread (`vars.FACTORY_ALERT_ISSUE`) — an unexplained silent factory is
+indistinguishable from a broken one, which is the failure mode this whole sub-project exists to
+remove.

--- a/docs/knowledge/patterns/factory-kill-switch.md
+++ b/docs/knowledge/patterns/factory-kill-switch.md
@@ -59,6 +59,13 @@ gh api --method PUT \
 Browser equivalent: `https://github.com/Muddl/riot-api-mcp-server/settings/rules` → the ruleset →
 Enforcement status → **Disabled** → Save.
 
+**This will turn `ruleset-drift.yml` red the next time it runs, on purpose.** `check-drift.sh`
+compares `enforcement` like any other field, so a disabled ruleset *is* drift by its definition —
+the daily job will go red and @-mention `FACTORY_ALERT_ISSUE` every morning until the ruleset is
+re-applied. That is correct behaviour, not a second incident: say so on the alert thread (see
+"After using any rung" below) so a deliberate rollback is not re-litigated as a fresh problem at
+07:17 UTC.
+
 `enforcement: "evaluate"` (dry-run) is **GitHub Enterprise only** and is not available on this
 repository — there is no "try it safely" middle setting. Disabled or active.
 

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -112,7 +112,7 @@ the program's first real evidence the sub-project-0/1a core generalizes, not jus
 
 Two standing gates remain **pending / user-owed**, carried forward rather than claimed passed, exactly
 as for 1a/1b: the live transport handshake (stdio + sse) and TFT-v1 endpoint-path verification against
-the live Riot developer portal (continuously re-verified post-merge by the live eval harness once its
+the live Riot developer portal (continuously re-verified by dispatched runs of the live eval harness once its
 TFT generalization lands) — both require a live `RIOT_API_KEY` and a human in the loop.
 
 ### 3 — Valorant server ⏳
@@ -185,7 +185,7 @@ Beyond the primitives, the quality gates the pattern depends on are largely buil
 
 | Factory component | Here today |
 |---|---|
-| Automated quality gates | `./gradlew build` — tests, ArchUnit, JaCoCo, Spotless — plus the post-merge live eval harness ([ADR-0012](decisions/ADR-0012-live-eval-harness.md)) |
+| Automated quality gates | `./gradlew build` — tests, ArchUnit, JaCoCo, Spotless — plus the dispatch-only live eval harness ([ADR-0012](decisions/ADR-0012-live-eval-harness.md)) |
 | Shared tooling | Agents run the same Gradle build and the same project skills a human runs; there is no agent-only path |
 | Standardized inputs | KB hydrate/persist protocol, project skills, `CLAUDE.md` |
 | Back-pressure before review | ArchUnit, Spotless, and the negative-control tests fail locally, pre-PR — Stripe's "shift feedback left" |
@@ -208,7 +208,7 @@ which also **corrects three claims this section previously made** (see below).
 
 | # | Sub-project | State | Notes |
 |---|---|---|---|
-| **F0** | Harden the gate | ⏳ Not started — [plan](../superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md) | Ruleset surgery, the fork-PR fix that must precede any required check, bounds/kill-switch/alerting, #71, and the stale-doc sweep. Ships **no new agent behaviour**, so it is the only sub-project fully verifiable before it is depended on. |
+| **F0** | Harden the gate | ✅ Shipped | [ADR-0019](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md). Ruleset `8769144` split into R1 (`~ALL`) + R2 (`~DEFAULT_BRANCH`, `Build & verify` required); fork PRs unblocked first; timeouts, `FACTORY_ENABLED` kill switch, `@Muddl` failure alerts, local-only apply script and a daily drift check. #71 closed and the stale-doc sweep done. |
 | **F1** | Machine identity (GitHub App) | ⏳ Not started | Retires the PAT. Desk-only — a private key is not a phone artifact. |
 | **F2** | Issue intake, two-phase | ⏳ Not started — [plan](../superpowers/plans/2026-08-01-factory-f2-issue-intake.md) | `agent:plan` commits a plan and posts its SHA; `agent:go` implements *that SHA*, checked by a deterministic `git diff --exit-code`. The work-queue primitive. **Needs F0 first** — the current `~ALL` PR-required rule rejects `agent:go`'s second push to an existing branch. |
 | **F3** | Machine-emitted run traces | ⏳ Not started | The event stream, restricted to facts non-agent steps emit. Blocked on #71. |
@@ -233,15 +233,16 @@ which also **corrects three claims this section previously made** (see below).
   secrets included, into the Actions log and auto-enables under `ACTIONS_STEP_DEBUG`. This
   repository, its logs, and its artifacts are **public**. Uploading the `execution_file` artifact is
   the same content class in a different container and is rejected on the same grounds.
-- **The live eval does not run post-merge.** `live-eval.yml` is `workflow_dispatch:` only — the
-  `push` trigger was removed and never replaced. The stale claim is still live in this file (below,
-  under sub-projects 2 and 3 and in the deferred/standing-constraint tables), in `CLAUDE.md`, in
-  `README.md`, in `CONTRIBUTING.md`, and inside accepted **ADR-0012** and **ADR-0017**. It is flagged
-  here rather than fixed in place because ADRs are **amended, never edited**, so the sweep is a
-  single coherent change owned by F0 — but no reader should reach those sentences without knowing
-  they are wrong. The practical consequence is the one that matters: **merges get no live coverage
-  unless someone dispatches the workflow by hand**, and `gotchas.md` records three bug classes that
-  only the live eval has ever caught, every one of which passed the offline suite.
+- **The live eval never ran on merge.** `live-eval.yml` is `workflow_dispatch:` only — the `push`
+  trigger was removed and never replaced. The stale claim was live in this file (below, under
+  sub-projects 2 and 3 and in the deferred/standing-constraint tables), in `CLAUDE.md`, in
+  `README.md`, in `CONTRIBUTING.md`, and inside accepted **ADR-0012** and **ADR-0017**. F0's sweep
+  ([ADR-0019](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md)) corrected the prose
+  everywhere outside immutable history; ADR-0012 and ADR-0017 got dated amendment blockquotes rather
+  than a silent edit. The practical consequence is the one that matters regardless of doc wording:
+  **merges get no live coverage unless someone dispatches the workflow by hand**, and `gotchas.md`
+  records three bug classes that only the live eval has ever caught, every one of which passed the
+  offline suite.
 
 ### Failure modes to design against
 
@@ -313,8 +314,8 @@ Real and wanted, deliberately not scheduled. Recorded so they are not re-derived
 | Publishing libraries as Maven artifacts | Not planned. Libraries are versioned for provenance and consumed by project reference — see ADR-0010. |
 | Aggregate coverage report | When more than one server exists. |
 | ~~Claude Code Actions integration rework~~ | **Shipped** ([ADR-0015](decisions/ADR-0015-repo-maintenance-automation.md)). The PR reviewer now posts real reviews, `@claude` can respond, and a weekly `/housekeeping` cron opens maintenance PRs — all on `CLAUDE_CODE_OAUTH_TOKEN`, separate from live-eval's `ANTHROPIC_API_KEY`. |
-| ~~Automated endpoint-path verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). Live agent-driven evals call every tool against the real Riot API post-merge; a wrong path returns 404 and fails the eval, so paths are verified continuously rather than by a human opening the portal. |
-| ~~Automated transport-handshake verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). The suite runs over both stdio and sse each post-merge run; a successful stdio session is the stdout-purity check. |
+| ~~Automated endpoint-path verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). Live agent-driven evals call every tool against the real Riot API on each dispatched run; a wrong path returns 404 and fails the eval, so paths are verified by running the harness rather than by a human opening the portal. |
+| ~~Automated transport-handshake verification~~ | **Shipped** as part of the live eval harness (see [ADR-0012](decisions/ADR-0012-live-eval-harness.md)). The suite runs over both stdio and sse each dispatched run; a successful stdio session is the stdout-purity check. |
 
 ## Standing constraints
 
@@ -325,11 +326,11 @@ These hold across every sub-project:
 - **Riot endpoint paths are verified against the live developer portal**, never assumed from
   Context7 or model knowledge. Sub-project 0 found Context7 returned mostly Data Dragon and
   Valorant/TFT material when asked for a structured LoL reference. *As of
-  [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated post-merge by the live eval
-  harness (`eval/`), over both transports; the offline suite remains the pre-merge gate.*
+  [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated by the live eval
+  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite remains the pre-merge gate.*
 - **Green tests do not prove the server serves.** Every cycle verifies both transports with a real
   MCP handshake, including stdio's stdout purity. *As of
-  [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated post-merge by the live eval
-  harness (`eval/`), over both transports; the offline suite remains the pre-merge gate.*
+  [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated by the live eval
+  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite remains the pre-merge gate.*
 - **The intended consumer is a third party** installing against their own Riot API key. That raises
   the bar on tool naming, error messages, and key-gating behaviour.

--- a/docs/knowledge/roadmap.md
+++ b/docs/knowledge/roadmap.md
@@ -208,7 +208,7 @@ which also **corrects three claims this section previously made** (see below).
 
 | # | Sub-project | State | Notes |
 |---|---|---|---|
-| **F0** | Harden the gate | ✅ Shipped | [ADR-0019](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md). Ruleset `8769144` split into R1 (`~ALL`) + R2 (`~DEFAULT_BRANCH`, `Build & verify` required); fork PRs unblocked first; timeouts, `FACTORY_ENABLED` kill switch, `@Muddl` failure alerts, local-only apply script and a daily drift check. #71 closed and the stale-doc sweep done. |
+| **F0** | Harden the gate | ✅ Shipped (branch) — rulesets committed, applied separately | [ADR-0019](decisions/ADR-0019-gate-hardening-and-ruleset-topology.md). Ruleset `8769144` split into R1 (`~ALL`) + R2 (`~DEFAULT_BRANCH`, `Build & verify` required) is **committed but not yet applied**: `.github/rulesets/*.json` is the committed intent, and `scripts/rulesets/apply-rulesets.sh` must be run from a desk before the split is live. Also shipped: fork PRs unblocked first; timeouts, `FACTORY_ENABLED` kill switch, `@Muddl` failure alerts, the local-only apply script itself, and a daily drift check. #71 closed and the stale-doc sweep done. |
 | **F1** | Machine identity (GitHub App) | ⏳ Not started | Retires the PAT. Desk-only — a private key is not a phone artifact. |
 | **F2** | Issue intake, two-phase | ⏳ Not started — [plan](../superpowers/plans/2026-08-01-factory-f2-issue-intake.md) | `agent:plan` commits a plan and posts its SHA; `agent:go` implements *that SHA*, checked by a deterministic `git diff --exit-code`. The work-queue primitive. **Needs F0 first** — the current `~ALL` PR-required rule rejects `agent:go`'s second push to an existing branch. |
 | **F3** | Machine-emitted run traces | ⏳ Not started | The event stream, restricted to facts non-agent steps emit. Blocked on #71. |
@@ -327,10 +327,12 @@ These hold across every sub-project:
   Context7 or model knowledge. Sub-project 0 found Context7 returned mostly Data Dragon and
   Valorant/TFT material when asked for a structured LoL reference. *As of
   [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated by the live eval
-  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite remains the pre-merge gate.*
+  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite
+  remains the pre-merge gate.*
 - **Green tests do not prove the server serves.** Every cycle verifies both transports with a real
   MCP handshake, including stdio's stdout purity. *As of
   [ADR-0012](decisions/ADR-0012-live-eval-harness.md) this is automated by the live eval
-  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite remains the pre-merge gate.*
+  harness (`eval/`), over both transports, on dispatch rather than on merge; the offline suite
+  remains the pre-merge gate.*
 - **The intended consumer is a third party** installing against their own Riot API key. That raises
   the bar on tool naming, error messages, and key-gating behaviour.

--- a/scripts/rulesets/apply-rulesets.sh
+++ b/scripts/rulesets/apply-rulesets.sh
@@ -19,7 +19,13 @@ DRY_RUN=false
 # Argv validation comes first and is non-mutating, so it is safe to run before the GITHUB_ACTIONS
 # guard below — but that guard must still precede every gh api call and both apply() invocations.
 # An unrecognised flag (--dryrun, --dry_run, -n, --dry-run=true, ...) must never silently fall
-# through to a live apply.
+# through to a live apply. Nor may a stray second argument: "" --dry-run matches the empty-string
+# arm below and would otherwise perform a live apply while the operator believes it is a dry run.
+if [ "$#" -gt 1 ]; then
+  echo "too many arguments" >&2
+  exit 2
+fi
+
 case "${1:-}" in
   "") ;;
   --dry-run) DRY_RUN=true ;;

--- a/scripts/rulesets/apply-rulesets.sh
+++ b/scripts/rulesets/apply-rulesets.sh
@@ -15,7 +15,16 @@ REPO="${RULESET_REPO:-Muddl/riot-api-mcp-server}"
 R1_ID=8769144                       # existing ruleset, updated in place so its id stays stable
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.github/rulesets" && pwd)"
 DRY_RUN=false
-[ "${1:-}" = "--dry-run" ] && DRY_RUN=true
+
+# Argv validation comes first and is non-mutating, so it is safe to run before the GITHUB_ACTIONS
+# guard below — but that guard must still precede every gh api call and both apply() invocations.
+# An unrecognised flag (--dryrun, --dry_run, -n, --dry-run=true, ...) must never silently fall
+# through to a live apply.
+case "${1:-}" in
+  "") ;;
+  --dry-run) DRY_RUN=true ;;
+  *) echo "unknown argument: $1" >&2; exit 2 ;;
+esac
 
 if [ -n "${GITHUB_ACTIONS:-}" ]; then
   echo "REFUSING: this script must never run in GitHub Actions. See ADR-0019." >&2
@@ -26,16 +35,31 @@ command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq not found" >&2; exit 1; }
 gh auth status >/dev/null || { echo "gh is not authenticated" >&2; exit 1; }
 
-ruleset_id_by_name() {
-  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$1\") | .id" | head -n1
+ruleset_ids_by_name() {  # prints one id per line: 0, 1, or (ambiguous) more than 1
+  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$1\") | .id"
 }
 
 apply() {  # apply <json-file> [known-id]
-  local file="$DIR/$1" id="${2:-}" name
+  local file="$DIR/$1" id="${2:-}" name ids count
   name="$(jq -r .name "$file")"
-  [ -n "$id" ] || id="$(ruleset_id_by_name "$name")"
+  if [ -z "$id" ]; then
+    ids="$(ruleset_ids_by_name "$name")"
+    if [ -n "$ids" ]; then
+      count="$(printf '%s\n' "$ids" | wc -l)"
+      if [ "$count" -ne 1 ]; then
+        echo "FATAL: $count live rulesets are named \"$name\" (ambiguous, expected at most one)." >&2
+        echo "IDs: $(printf '%s ' $ids)" >&2
+        exit 1
+      fi
+      id="$ids"
+    fi
+  fi
   if $DRY_RUN; then
-    echo "would ${id:+PUT $id}${id:+ }${id:-POST} <- $1 ($name)"
+    if [ -n "$id" ]; then
+      echo "would PUT $id <- $1 ($name)"
+    else
+      echo "would POST <- $1 ($name)"
+    fi
     return 0
   fi
   if [ -n "$id" ]; then

--- a/scripts/rulesets/apply-rulesets.sh
+++ b/scripts/rulesets/apply-rulesets.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Apply the committed ruleset JSON to GitHub. LOCAL ONLY — never from CI.
+#
+# Why local: a workflow able to rewrite rulesets could delete the approval requirement, which is
+# strictly stronger than approving its own work and violates the standing constraint that
+# automation may propose but never approve. Ruleset writes need `administration: write`; this
+# script uses the maintainer's own `gh` credential (an OAuth token with `repo` scope, or a
+# fine-grained PAT with Administration: read and write). No such credential exists in Actions,
+# and none is ever added.
+#
+# Usage:  scripts/rulesets/apply-rulesets.sh [--dry-run]
+set -euo pipefail
+
+REPO="${RULESET_REPO:-Muddl/riot-api-mcp-server}"
+R1_ID=8769144                       # existing ruleset, updated in place so its id stays stable
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.github/rulesets" && pwd)"
+DRY_RUN=false
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=true
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  echo "REFUSING: this script must never run in GitHub Actions. See ADR-0019." >&2
+  exit 1
+fi
+
+command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq not found" >&2; exit 1; }
+gh auth status >/dev/null || { echo "gh is not authenticated" >&2; exit 1; }
+
+ruleset_id_by_name() {
+  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$1\") | .id" | head -n1
+}
+
+apply() {  # apply <json-file> [known-id]
+  local file="$DIR/$1" id="${2:-}" name
+  name="$(jq -r .name "$file")"
+  [ -n "$id" ] || id="$(ruleset_id_by_name "$name")"
+  if $DRY_RUN; then
+    echo "would ${id:+PUT $id}${id:+ }${id:-POST} <- $1 ($name)"
+    return 0
+  fi
+  if [ -n "$id" ]; then
+    echo "PUT  $REPO/rulesets/$id  <- $1"
+    gh api --method PUT "repos/$REPO/rulesets/$id" --input "$file" >/dev/null
+  else
+    echo "POST $REPO/rulesets      <- $1"
+    gh api --method POST "repos/$REPO/rulesets" --input "$file" >/dev/null
+  fi
+}
+
+# ORDER IS LOAD-BEARING. R2 carries the approval requirement that R1 is about to lose; creating
+# R2 first means the default branch is never, even briefly, without one.
+apply R2-default-branch.json
+apply R1-all-branches.json "$R1_ID"
+
+echo
+echo "Applied. Verifying against the committed JSON:"
+exec "$(dirname "${BASH_SOURCE[0]}")/check-drift.sh"

--- a/scripts/rulesets/check-drift.sh
+++ b/scripts/rulesets/check-drift.sh
@@ -18,12 +18,19 @@ STRIP='del(.id, .node_id, ._links, .created_at, .updated_at, .source, .source_ty
 
 for file in R1-all-branches.json R2-default-branch.json; do
   name="$(jq -r .name "$DIR/$file")"
-  id="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id" | head -n1)"
-  if [ -z "$id" ]; then
+  ids="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id")"
+  if [ -z "$ids" ]; then
     echo "::error title=Ruleset drift::No live ruleset named \"$name\". Expected from $file."
     status=1
     continue
   fi
+  count="$(printf '%s\n' "$ids" | wc -l)"
+  if [ "$count" -ne 1 ]; then
+    echo "::error title=Ruleset drift::Found $count live rulesets named \"$name\" (ambiguous, expected exactly one). IDs: $(printf '%s ' $ids)"
+    status=1
+    continue
+  fi
+  id="$ids"
   gh api "repos/$REPO/rulesets/$id" | jq -S "$STRIP" > "$TMP/live.json"
   jq -S . "$DIR/$file" > "$TMP/want.json"
   if diff -u "$TMP/want.json" "$TMP/live.json" > "$TMP/diff.txt"; then
@@ -34,6 +41,25 @@ for file in R1-all-branches.json R2-default-branch.json; do
     status=1
   fi
 done
+
+# The loop above only confirms the two tracked rulesets match; it says nothing about whether a
+# third, untracked ruleset also exists live. GitHub documents nothing about how bypass_actors are
+# evaluated when multiple rulesets apply to the same ref, so an extra ruleset — added by hand, or
+# left behind live after a committed JSON was renamed (which makes the applier POST a new one
+# instead of updating the old) — is a route to weakening the exact property this repo relies on,
+# invisibly to the loop above. Assert the live set of ruleset names is exactly {R1, R2}, no more.
+expected_names="$(printf '%s\n' "$(jq -r .name "$DIR/R1-all-branches.json")" "$(jq -r .name "$DIR/R2-default-branch.json")" | sort)"
+live_names="$(gh api "repos/$REPO/rulesets" --jq '.[].name' | sort)"
+if [ -n "$live_names" ]; then
+  extra_names="$(comm -23 <(printf '%s\n' "$live_names") <(printf '%s\n' "$expected_names"))"
+else
+  extra_names=""
+fi
+if [ -n "$extra_names" ]; then
+  echo "::error title=Ruleset drift::Unexpected live ruleset(s) not tracked by any committed JSON:"
+  printf '%s\n' "$extra_names" | sed 's/^/  - /'
+  status=1
+fi
 
 if [ "$status" -ne 0 ]; then
   echo

--- a/scripts/rulesets/check-drift.sh
+++ b/scripts/rulesets/check-drift.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Compare the live rulesets against the committed JSON. READ ONLY — makes no writes at all.
+# Runs both locally and from ruleset-drift.yml so there is exactly one implementation.
+#
+# `.github/rulesets/` is not a GitHub-recognised path; nothing on GitHub's side reads it. Without
+# this check the committed JSON is documentation cosplaying as configuration — ADR-0018's exact
+# failure shape, artifact present, property absent.
+set -euo pipefail
+
+REPO="${RULESET_REPO:-Muddl/riot-api-mcp-server}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.github/rulesets" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+status=0
+
+# Server-generated fields that are not part of the desired state.
+STRIP='del(.id, .node_id, ._links, .created_at, .updated_at, .source, .source_type, .current_user_can_bypass)'
+
+for file in R1-all-branches.json R2-default-branch.json; do
+  name="$(jq -r .name "$DIR/$file")"
+  id="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id" | head -n1)"
+  if [ -z "$id" ]; then
+    echo "::error title=Ruleset drift::No live ruleset named \"$name\". Expected from $file."
+    status=1
+    continue
+  fi
+  gh api "repos/$REPO/rulesets/$id" | jq -S "$STRIP" > "$TMP/live.json"
+  jq -S . "$DIR/$file" > "$TMP/want.json"
+  if diff -u "$TMP/want.json" "$TMP/live.json" > "$TMP/diff.txt"; then
+    echo "ok   $file (id $id) matches live"
+  else
+    echo "::error title=Ruleset drift::Live ruleset $id (\"$name\") differs from $file"
+    cat "$TMP/diff.txt"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "Live branch protection no longer matches the committed intent. Either someone hand-edited"
+  echo "a ruleset in the UI, or the committed JSON was changed without applying it. Reconcile with"
+  echo "scripts/rulesets/apply-rulesets.sh (locally, at a desk) or update the JSON to match."
+fi
+exit "$status"

--- a/scripts/rulesets/check-drift.sh
+++ b/scripts/rulesets/check-drift.sh
@@ -18,7 +18,9 @@ STRIP='del(.id, .node_id, ._links, .created_at, .updated_at, .source, .source_ty
 
 for file in R1-all-branches.json R2-default-branch.json; do
   name="$(jq -r .name "$DIR/$file")"
-  ids="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id")"
+  # --paginate: the default 30-items-per-page listing would silently miss a ruleset past the
+  # first page, which is exactly the hole the completeness assertion below exists to close.
+  ids="$(gh api --paginate "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id")"
   if [ -z "$ids" ]; then
     echo "::error title=Ruleset drift::No live ruleset named \"$name\". Expected from $file."
     status=1
@@ -49,7 +51,7 @@ done
 # instead of updating the old) — is a route to weakening the exact property this repo relies on,
 # invisibly to the loop above. Assert the live set of ruleset names is exactly {R1, R2}, no more.
 expected_names="$(printf '%s\n' "$(jq -r .name "$DIR/R1-all-branches.json")" "$(jq -r .name "$DIR/R2-default-branch.json")" | sort)"
-live_names="$(gh api "repos/$REPO/rulesets" --jq '.[].name' | sort)"
+live_names="$(gh api --paginate "repos/$REPO/rulesets" --jq '.[].name' | sort)"
 if [ -n "$live_names" ]; then
   extra_names="$(comm -23 <(printf '%s\n' "$live_names") <(printf '%s\n' "$expected_names"))"
 else


### PR DESCRIPTION
Implements #73 — sub-project F0 of the software factory. Closes #71.
Spec: `docs/superpowers/specs/2026-08-01-software-factory-decomposition-design.md` §1.
Plan: `docs/superpowers/plans/2026-08-01-factory-f0-harden-the-gate.md`.
Decision record: **ADR-0019**.

## Expect no Claude review on this PR — this is correct, not a failure

`claude-code-action` hard-requires the workflow file to be byte-identical to the copy on the
default branch. This PR edits `claude-code-review.yml` and `claude.yml`, so the action **skips
itself** with `Skipping action due to workflow validation`, recorded as an *annotation on a
successful job*. Do not read the missing review as the reviewer silently failing; see the
matching entry in `docs/knowledge/gotchas.md`. The reviewer resumes on the next PR, once these
files are on `master`.

## Live configuration is NOT yet applied

**The rulesets in this PR are committed intent, not live configuration.** `master` today still
has the single pre-existing ruleset (`~ALL`, `pull_request{1}`, **no required status checks**).
Nothing in this branch changes that until `scripts/rulesets/apply-rulesets.sh` is run from a
desk. The roadmap row, ADR-0019 and `gotchas.md` all say so explicitly rather than describing
the post-apply state — an earlier draft did not, and the final review caught it as exactly the
"artifact present, property absent" failure this sub-project exists to eliminate.

## Merge BEFORE applying the rulesets

The plan had this backwards and the final review corrected it. Applying first opens a window in
which `Build & verify` is required on `master` while `master`'s `ci.yml` still lacks the fork-PR
fix — any fork PR opened in that window would be permanently unmergeable. Merging first is
strictly safer: no ruleset is applied yet, and the pre-existing ruleset already requires one
approval with the maintainer exempt, so merge behaviour is unchanged.

Ordered steps for the maintainer:

1. **Fix the alert variable.** `FACTORY_ENABLED=true` is set correctly. But `FACTORY_ALERT_ISSUES`
   (plural, value `true`) is wrong on both counts — every workflow reads the singular
   `vars.FACTORY_ALERT_ISSUE` and expects an **issue number**. Create the tracking issue, set
   `FACTORY_ALERT_ISSUE` to its number, delete the plural one. *If skipped:* both alert paths hit
   their unset-guard and `exit 1`.
2. **Create `RULESET_READ_TOKEN`** — fine-grained, this repo only, **Administration: read**, nothing
   else. *If skipped:* `ruleset-drift.yml` goes red daily. Its schedule only activates once the
   workflow is on the default branch, so do this at or before merge.
3. **Merge this PR.** Confirm `Build & verify` is green first. #71 auto-closes via the trailer in
   `dcfc62e`.
4. **Run `scripts/rulesets/apply-rulesets.sh --dry-run`, then for real — from a desk, never CI.**
   Expect `would POST <- R2-default-branch.json` and `would PUT 8769144 <- R1-all-branches.json`.
5. **Expect the first drift run to be red, and reconcile.** GitHub echoes defaults the committed
   JSON does not carry (e.g. `required_reviewers: []` on the `pull_request` rule). Copy the *live*
   side into the committed JSON — GitHub's echo is the authority on its own normalisation. Note
   `jq -S` sorts keys but **not array elements**: if `rules[]` or `bypass_actors[]` come back in a
   different order, reorder the committed JSON rather than relaxing the comparator.
6. **Verify the property, not the exit status.** Open a throwaway PR with a deliberately failing
   build and confirm `gh pr view --json mergeStateStatus` returns `BLOCKED` — not `UNSTABLE`,
   which would mean R2 never took effect.
7. Then update the roadmap row to unqualified "Shipped".

Still handed over: the rollback probe, the phone kill-switch ladder exercise, and the fork-PR test.

Rollback, executable from a phone:
`gh api --method PUT repos/Muddl/riot-api-mcp-server/rulesets/8769144 -f enforcement=disabled`
Note this counts as drift, so the daily check will go red until re-applied — by design.

## Deviations from the plan, both on explicit maintainer ruling

- **The ruleset scripts ship hardened beyond the plan's verbatim text.** A review found four
  Important gaps: ambiguous ruleset-name lookups silently took the first match; `check-drift.sh`
  never asserted R1/R2 were the *only* live rulesets (so a hand-added third ruleset carrying an
  `exempt` bypass would pass green); `apply-rulesets.sh` treated a mistyped `--dry-run` as a live
  apply; and the dry-run line printed the id twice. All fixed, recorded in ADR-0019.
- **`integration_id: 15368` is now pinned** on R2's required check. The plan left this open. Without
  it, any token with `checks: write` could satisfy the required check by posting a passing status
  of that name with no build behind it.

## One honest note on process

A fix report in this branch claimed a specific edge case was "verified in isolation" when the
transcript it pointed at contained no such test. The guard is correct by inspection and was
re-derived independently — but on a branch whose governing constraint is *"a green run is not
proof of success"*, an unbacked evidence claim is the same defect one level up. Recording it
rather than quietly dropping it.

## What this buys, stated accurately

Once applied, machine identities cannot merge red — **except ones that inherit the admin role**.
The bypass is scoped to `RepositoryRole` `actor_id: 5`, so any PAT minted under the admin account
inherits it, including `HOUSEKEEPING_TOKEN`, which already holds `Pull requests: read/write`.
**F1 (GitHub App) is what actually closes that**, since an App installation authenticates as
`actor_type: Integration`. Residual risk stated, not solved.