### PR TITLE
fix(ci): reconcile R2 ruleset JSON with GitHub's echoed defaults

### DIFF
--- a/.github/rulesets/R2-default-branch.json
+++ b/.github/rulesets/R2-default-branch.json
@@ -30,12 +30,14 @@
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_approving_review_count": 1,
-        "required_review_thread_resolution": false
+        "required_review_thread_resolution": false,
+        "required_reviewers": []
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
             "context": "Build & verify",


### PR DESCRIPTION
Follow-up to #81. The rulesets were applied live from a desk; this is the reconciliation step
ADR-0019 and the F0 plan anticipated.

GitHub echoed back two fields the committed JSON did not carry:

| Rule | Field |
|---|---|
| `pull_request` | `"required_reviewers": []` |
| `required_status_checks` | `"do_not_enforce_on_create": false` |

Both are GitHub's normalisation of a request that omitted them. `check-drift.sh` compares
**exactly**, deliberately — an exact diff is what makes a UI hand-edit detectable — so the fix is
to match the echo, never to relax the comparator to a subset match.

**Live state after the apply:**

```
ok   R1-all-branches.json (id 8769144)  matches live
ok   R2-default-branch.json (id 20203635) matches live
```

R1 (`~ALL`: deletion, non_fast_forward) was updated in place, so its id — and therefore the
phone-executable rollback command — stays stable. R2 (`~DEFAULT_BRANCH`: `pull_request{1}` +
`required_status_checks["Build & verify", integration_id 15368]`) is new at id `20203635`.

This PR is itself the first real exercise of the gate: it needs a green `Build & verify` and one
approval before it can merge.