### PR TITLE
docs(kb): record the reviewer's usage-limit failure mode and retire stale PAT wording

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -146,7 +146,8 @@ jobs:
           # every push here died with "Invalid username or token" (exit 128). Setting GH_TOKEN does
           # not help on its own: it authenticates `gh`, never `git`.
           #
-          # Restore a clean origin, then pass the PAT as a one-shot header on the push itself. An
+          # Restore a clean origin, then pass the App installation token as a one-shot header on
+          # the push itself. An
           # embedded `https://x-access-token:$TOKEN@...` remote would work too, but persists the
           # token in .git/config for the rest of the job; `actions/checkout` avoids exactly that by
           # using an extraheader, and this step — which exists to route around a credential footgun

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -550,3 +550,38 @@ Observed 2026-08-01 on probe PR #87: an assertion of `gh pr view --json author -
 `author.login` was `app/muddlbot`, not `muddlbot[bot]`. The failure looks exactly like the identity
 swap being wrong when it is not; check the REST endpoint (`gh api .../pulls/N --jq .user.login`)
 before concluding that it is.
+
+## The reviewer's flat-rate seat can hit its usage limit mid-review, and the failure names no cause
+
+`claude-code-review.yml` failed on PR #89, run `30727557013`, 2026-08-02, verbatim:
+
+```
+##[error]Claude result reported subtype success with is_error:true (run did not complete successfully)
+##[error]Action failed with error: Claude execution failed: result is_error:true
+##[error]Process completed with exit code 1.
+```
+
+The cause: the flat-rate `CLAUDE_CODE_OAUTH_TOKEN` seat hit its **max session usage** partway
+through the review. Not a code fault, not a permission problem, and not an actor refusal — the
+action simply could not finish. Confirmed by the maintainer, who recognised the error shape.
+
+This repo already has two other recorded reviewer failure modes, and this is neither of them:
+
+- "`claude-code-action` is silently skipped when the workflow file differs from the default
+  branch" — green job, an annotation, no review posted.
+- "`allowed_bots` pins a literal slug — a wrong entry fails the review job red, it does not
+  decline quietly" — fails red with an explicit `Workflow initiated by non-human actor: <slug>
+  (type: Bot)` message naming the cause.
+
+The usage-limit failure fails red like the second, but names **no** cause: the message is a
+generic `is_error:true`, visually indistinguishable from a genuine failure of the code under
+review, and it arrives with the same `@Muddl` alert as any other red job. The tell: a re-run of
+the identical job, same commit, after the usage window reset went green and posted a full review.
+
+This is one concrete mechanism behind open issue #80 ("The PR reviewer can burn a full run and
+post nothing, indistinguishably from having reviewed") — not necessarily the only one, and this
+entry does not close it.
+
+Operational consequence: the factory's review gate degrades to "not reviewed" under usage
+pressure. Because the failure is loud, the correct response is to re-run once the session window
+has reset, not to investigate the PR's code, and never to merge past it.


### PR DESCRIPTION
## Summary

Two small closeout items from sub-project F1:

1. **New gotcha** in `docs/knowledge/gotchas.md`: the PR reviewer
   (`claude-code-review.yml`) can fail with a generic `is_error:true` when the
   flat-rate `CLAUDE_CODE_OAUTH_TOKEN` seat hits its max session usage
   mid-review. This is a real observed failure on PR #89, run `30727557013`
   (2026-08-02) — confirmed by the maintainer, and reproduced as retry-able:
   an identical re-run after the usage window reset went green with a full
   review. The entry distinguishes this from the two other recorded reviewer
   failure modes (silent skip on a stale workflow file; the `allowed_bots`
   red-fail naming its cause) and flags it as one concrete mechanism behind
   open issue #80, without claiming to close it.

2. **Stale PAT wording** in `.github/workflows/housekeeping.yml`: one comment
   line describing the push-step credential handover still said "pass the
   PAT as a one-shot header", left over from before ADR-0020 moved this
   workflow to a GitHub App installation token. Corrected to say "App
   installation token". Comment-only change — no `run:` logic, conditionals,
   or step ordering touched. The `git remote set-url` / `::add-mask::` /
   `extraheader` mechanics are unchanged and still correct.

Unlike the F1 PR, this one does not modify `claude-code-review.yml` itself,
so it **will** receive a normal Claude review.

Refs #74

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SHHXD6CHRYwFbWfbt9drap
